### PR TITLE
format body para. of generated test cases

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/output/TestCaseWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/TestCaseWriter.kt
@@ -1,5 +1,6 @@
 package org.evomaster.core.output
 
+import org.evomaster.core.output.formatter.OutputFormatter
 import org.evomaster.core.problem.rest.RestCallAction
 import org.evomaster.core.problem.rest.RestCallResult
 import org.evomaster.core.problem.rest.param.BodyParam
@@ -219,13 +220,17 @@ class TestCaseWriter {
             //TODO check on body
         }
     }
-
     private fun handleBody(call: RestCallAction, lines: Lines) {
+        handleBody(call, lines, true)
+    }
+
+    private fun handleBody(call: RestCallAction, lines: Lines, readable: Boolean) {
         call.parameters.find { p -> p is BodyParam }
                 ?.let {
                     lines.add(".contentType(\"application/json\")")
 
-                    val body = it.gene.getValueAsPrintableString()
+                    val body = if(readable) OutputFormatter.JSON_FORMATTER.getFormatted(it.gene.getValueAsPrintableString())
+                                else it.gene.getValueAsPrintableString();
 
                     //needed as JSON uses ""
                     val bodyLines = body.split("\n").map { s ->

--- a/core/src/main/kotlin/org/evomaster/core/output/formatter/MismatchedFormatException.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/formatter/MismatchedFormatException.kt
@@ -1,0 +1,3 @@
+package org.evomaster.core.output.formatter
+
+class MismatchedFormatException(val formatter: OutputFormatter, val msg:String): Exception( formatter.name +" cannot format "+msg)

--- a/core/src/main/kotlin/org/evomaster/core/output/formatter/OutputFormatter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/formatter/OutputFormatter.kt
@@ -1,0 +1,63 @@
+package org.evomaster.core.output.formatter
+
+import com.google.gson.GsonBuilder
+import com.google.gson.Gson
+import com.google.gson.JsonSyntaxException
+
+/**
+ * @author: manzhang
+ * @date: 27/08/2018
+ * @description: this class can be extended for supporting different styles of outputs (i.e., test cases),
+ *                 currently only json is supported with string input
+ */
+open abstract class OutputFormatter (val name: String) {
+
+    companion object {
+        private var formatters = mutableMapOf<String, OutputFormatter>()
+
+        //this function can be used to find the proper formatter
+        fun findFormatter(type: String): OutputFormatter? {
+            return formatters.get(type)
+        }
+
+        fun registerFormatter(formatter: OutputFormatter){
+            formatters.put(formatter.name, formatter)
+        }
+
+        fun getFormatters():List<OutputFormatter>?{
+            if(formatters.size > 0)
+                return formatters.values.toList();
+            return null
+        }
+
+        val JSON_FORMATTER = object : OutputFormatter("JSON_FORMATTER"){
+            val gson = GsonBuilder().setPrettyPrinting().create()
+
+            override fun isValid(content: String): Boolean{
+                try{
+                    gson.fromJson(content, Object::class.java)
+                    return true
+                }catch (e : JsonSyntaxException ) {
+                    return false
+                }
+
+            }
+            override fun getFormatted(content: String): String{
+                if(this.isValid(content)){
+                    return gson.toJson(gson.fromJson(content, Object::class.java))
+                }
+                throw MismatchedFormatException(this, content)
+            }
+        }
+        init {
+            registerFormatter(JSON_FORMATTER);
+        }
+
+
+    }
+
+    abstract fun isValid(content: String): Boolean
+    abstract fun getFormatted(content: String): String
+
+
+}

--- a/core/src/test/kotlin/org/evomaster/core/outputformatter/TestJSONFormatter.kt
+++ b/core/src/test/kotlin/org/evomaster/core/outputformatter/TestJSONFormatter.kt
@@ -1,8 +1,10 @@
 package org.evomaster.core.outputformatter
 
+import org.evomaster.core.output.formatter.MismatchedFormatException
 import org.evomaster.core.output.formatter.OutputFormatter
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.assertThrows
 
 
 class TestJSONFormatter {
@@ -10,23 +12,30 @@ class TestJSONFormatter {
     @Test
     fun test(){
         assertTrue(OutputFormatter.getFormatters()?.size == 1 ?:false)
-        var body = "{" +
-                "\"authorId\":\"VZyJz8z_Eu2\", " +
-                "\"creationTime\":\"1921-3-13T10:18:56.000Z\", " +
-                "\"newsId\":\"L\"" +
-                "}";
-        print(OutputFormatter.JSON_FORMATTER.getFormatted(body))
+        val body = """
+                {
+                   "authorId": "VZyJz8z_Eu2",
+                   "creationTime": "1921-3-13T10:18:56.000Z",
+                   "newsId": "L"
+                }
+                """
+        OutputFormatter.JSON_FORMATTER.getFormatted(body)
     }
 
 
     @Test
     fun testMismatched(){
         assertTrue(OutputFormatter.getFormatters()?.size == 1 ?:false)
-        var body =
-                "\"authorId\":\"VZyJz8z_Eu2\", " +
-                "\"creationTime\":\"1921-3-13T10:18:56.000Z\", " +
-                "\"newsId\":\"L\"" +
-                "}";
-        print(OutputFormatter.JSON_FORMATTER.getFormatted(body))
+        val body = """
+
+                   "authorId": "VZyJz8z_Eu2",
+                   "creationTime": "1921-3-13T10:18:56.000Z",
+                   "newsId": "L"
+                }
+                """
+
+        assertThrows<MismatchedFormatException>{
+            OutputFormatter.JSON_FORMATTER.getFormatted(body)
+        }
     }
 }

--- a/core/src/test/kotlin/org/evomaster/core/outputformatter/TestJSONFormatter.kt
+++ b/core/src/test/kotlin/org/evomaster/core/outputformatter/TestJSONFormatter.kt
@@ -1,0 +1,32 @@
+package org.evomaster.core.outputformatter
+
+import org.evomaster.core.output.formatter.OutputFormatter
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+
+
+class TestJSONFormatter {
+
+    @Test
+    fun test(){
+        assertTrue(OutputFormatter.getFormatters()?.size == 1 ?:false)
+        var body = "{" +
+                "\"authorId\":\"VZyJz8z_Eu2\", " +
+                "\"creationTime\":\"1921-3-13T10:18:56.000Z\", " +
+                "\"newsId\":\"L\"" +
+                "}";
+        print(OutputFormatter.JSON_FORMATTER.getFormatted(body))
+    }
+
+
+    @Test
+    fun testMismatched(){
+        assertTrue(OutputFormatter.getFormatters()?.size == 1 ?:false)
+        var body =
+                "\"authorId\":\"VZyJz8z_Eu2\", " +
+                "\"creationTime\":\"1921-3-13T10:18:56.000Z\", " +
+                "\"newsId\":\"L\"" +
+                "}";
+        print(OutputFormatter.JSON_FORMATTER.getFormatted(body))
+    }
+}


### PR DESCRIPTION
The original code of TestCaseWriter allows formatting json string if "\n" exists.  So I only create a formatter for json string (add "\n"s) using gson as shown in OutputFormatter.kt. This class can be also extended for another formats.

In addition, we may also format outputs (i.e., getFormattedString() ) based on the type, such as BodyParam or ObjectGene. But I just take string currently to reduce changes on original code.