### PR TITLE
bugfix in RestSampler

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/database/DbAction.kt
+++ b/core/src/main/kotlin/org/evomaster/core/database/DbAction.kt
@@ -78,8 +78,7 @@ class DbAction(
                 /**
                  * TIMESTAMP is assumed to be a Date field
                  */
-                TIMESTAMP ->
-                    SqlTimestampGene(it.name)
+                TIMESTAMP -> SqlTimestampGene(it.name)
                 /**
                  * CLOB(N) stores a UNICODE document of length N
                  */

--- a/core/src/main/kotlin/org/evomaster/core/search/gene/DateTimeGene.kt
+++ b/core/src/main/kotlin/org/evomaster/core/search/gene/DateTimeGene.kt
@@ -21,7 +21,14 @@ open class DateTimeGene(
     )
 
     override fun randomize(randomness: Randomness, forceNewValue: Boolean) {
-
+        /**
+         * If forceNewValue==true both date and time
+         * get a new value, but it only might need
+         * one to be different to get a new value.
+         *
+         * Shouldn't this method decide randomly if
+         * date, time or both get a new value?
+         */
         date.randomize(randomness, forceNewValue)
         time.randomize(randomness, forceNewValue)
     }

--- a/core/src/main/kotlin/org/evomaster/core/search/gene/GeneUtils.kt
+++ b/core/src/main/kotlin/org/evomaster/core/search/gene/GeneUtils.kt
@@ -7,18 +7,18 @@ object GeneUtils {
      * Given a number [x], return its string representation, with padded 0s
      * to have a defined [length]
      */
-    fun padded(x: Int, length: Int) : String {
+    fun padded(x: Int, length: Int): String {
 
-        require(length >= 0){"Negative length"}
+        require(length >= 0) { "Negative length" }
 
         val s = x.toString()
 
-        require(length >= s.length){"Value is too large for chosen length"}
+        require(length >= s.length) { "Value is too large for chosen length" }
 
-        return if(x >=0 ){
+        return if (x >= 0) {
             s.padStart(length, '0')
         } else {
-            "-${(-x).toString().padStart(length-1, '0')}"
+            "-${(-x).toString().padStart(length - 1, '0')}"
         }
     }
 
@@ -32,17 +32,17 @@ object GeneUtils {
      *
      * So, we simply "repair" such genes with only valid inputs.
      */
-    fun repairGenes(genes: Collection<Gene>){
+    fun repairGenes(genes: Collection<Gene>) {
 
-        for(g in genes){
-            when(g){
+        for (g in genes) {
+            when (g) {
                 is DateGene -> repairDateGene(g)
                 is TimeGene -> repairTimeGene(g)
             }
         }
     }
 
-    private fun repairDateGene(date: DateGene){
+    private fun repairDateGene(date: DateGene) {
 
         date.run {
             if (month.value < 1) {
@@ -56,35 +56,35 @@ object GeneUtils {
             }
 
             //February
-            if (month.value == 2 && day.value > 28){
+            if (month.value == 2 && day.value > 28) {
                 //for simplicity, let's not consider cases in which 29...
                 day.value = 28
-            } else if(day.value > 30 && (month.value.let { it == 11 || it == 4 || it == 6 || it == 9} )){
+            } else if (day.value > 30 && (month.value.let { it == 11 || it == 4 || it == 6 || it == 9 })) {
                 day.value = 30
-            } else if(day.value > 31){
+            } else if (day.value > 31) {
                 day.value = 31
             }
         }
     }
 
-    private fun repairTimeGene(time: TimeGene){
+    private fun repairTimeGene(time: TimeGene) {
 
         time.run {
-            if(hour.value < 0){
+            if (hour.value < 0) {
                 hour.value = 0
-            } else if(hour.value > 23){
+            } else if (hour.value > 23) {
                 hour.value = 23
             }
 
-            if(minute.value < 0){
+            if (minute.value < 0) {
                 minute.value = 0
-            } else if(minute.value > 59){
+            } else if (minute.value > 59) {
                 minute.value = 59
             }
 
-            if(second.value < 0){
+            if (second.value < 0) {
                 second.value = 0
-            } else if(second.value > 59){
+            } else if (second.value > 59) {
                 second.value = 59
             }
         }

--- a/core/src/test/kotlin/org/evomaster/core/search/gene/GeneUtilsTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/search/gene/GeneUtilsTest.kt
@@ -1,12 +1,13 @@
 package org.evomaster.core.search.gene
 
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import java.util.*
 
-internal class GeneUtilsTest{
+internal class GeneUtilsTest {
 
     @Test
-    fun testPadding(){
+    fun testPadding() {
 
         val x = 9
         val res = GeneUtils.padded(x, 2)
@@ -16,11 +17,51 @@ internal class GeneUtilsTest{
 
 
     @Test
-    fun testPaddingNegative(){
+    fun testPaddingNegative() {
 
         val x = -2
         val res = GeneUtils.padded(x, 3)
 
         assertEquals("-02", res)
+
+    }
+
+    @Test
+    fun testRepairDefaultDateGene() {
+        val gene = DateGene("date")
+        GeneUtils.repairGenes(listOf(gene))
+        GregorianCalendar(gene.year.value, gene.month.value, gene.day.value, 0, 0)
+    }
+
+    @Test
+    fun testRepairBrokenDateGene() {
+        val gene = DateGene("date", IntegerGene("year", 1998), IntegerGene("month", 4), IntegerGene("day", 31))
+        GeneUtils.repairGenes(gene.flatView())
+        GregorianCalendar(gene.year.value, gene.month.value, gene.day.value, 0, 0)
+        assertEquals(1998, gene.year.value)
+        assertEquals(4, gene.month.value)
+        assertEquals(30, gene.day.value)
+    }
+
+    @Test
+    fun testRepairBrokenSqlTimestampGene() {
+        val dateGene = DateGene("date", IntegerGene("year", 1998), IntegerGene("month", 4), IntegerGene("day", 31))
+        val timeGene = TimeGene("time", IntegerGene("hour", 23), IntegerGene("minute", 13), IntegerGene("second", 41), false)
+        val sqlTimestampGene = SqlTimestampGene("timestamp", dateGene, timeGene)
+
+        GeneUtils.repairGenes(sqlTimestampGene.flatView())
+        sqlTimestampGene.apply {
+            GregorianCalendar(this.date.year.value, this.date.month.value, this.date.day.value, this.time.hour.value, this.time.minute.value)
+        }
+        sqlTimestampGene.date.apply {
+            assertEquals(1998, this.year.value)
+            assertEquals(4, this.month.value)
+            assertEquals(30, this.day.value)
+        }
+        sqlTimestampGene.time.apply {
+            assertEquals(23, this.hour.value)
+            assertEquals(13, this.minute.value)
+            assertEquals(41, this.second.value)
+        }
     }
 }


### PR DESCRIPTION
RestSampler was not producing DbAction with repaired SqlTimestamp genes. This was due to the lack of a call to GeneUtils.repairGenes()