### PR TITLE
test failure is caused by a failure of file deletion in windows.

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/search/service/monitor/SearchProcessMonitor.kt
+++ b/core/src/main/kotlin/org/evomaster/core/search/service/monitor/SearchProcessMonitor.kt
@@ -125,18 +125,17 @@ class SearchProcessMonitor: SearchListener {
 
     private fun initMonitorProcessOutputs(){
         val path = Paths.get(config.processFiles)
+        if(config.showProgress) log.info("Deleting all files in ${path.toUri()}")
 
         if(Files.exists(path)){
             Files.walk(path)
                     .sorted(Comparator.reverseOrder())
                     .map(Path::toFile)
                     .forEach{
-                        t -> run{
-                        t.delete()
-                    } }
+                        if(!it.delete())
+                            log.warn("Fail to delete ${it.path}")
+                    }
         }
-        if(config.showProgress) log.info("all files in ${path.toUri().toString()} are deleted")
-
     }
     fun saveOverall(){
         setOverall()

--- a/core/src/test/kotlin/org/evomaster/core/search/service/ProcessMonitorTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/search/service/ProcessMonitorTest.kt
@@ -43,9 +43,6 @@ class ProcessMonitorTest{
 
         ff =  injector.getInstance(OneMaxFitness::class.java)
         config = injector.getInstance(EMConfig::class.java)
-
-        config.stoppingCriterion = EMConfig.StoppingCriterion.FITNESS_EVALUATIONS
-        config.processFiles = "target/process_data"
     }
 
 
@@ -75,6 +72,7 @@ class ProcessMonitorTest{
     @Test
     fun testEnableProcessMonitor(){
 
+        config.processFiles = "target/process_data"
         config.enableProcessMonitor = true
         config.showProgress = true
         config.processInterval = config.maxActionEvaluations
@@ -103,7 +101,7 @@ class ProcessMonitorTest{
 
     @Test
     fun testSerializedOneStep(){
-
+        config.processFiles = "target/process_data_1s"
         config.enableProcessMonitor = true
         config.showProgress = true
         config.processInterval = config.maxActionEvaluations
@@ -138,11 +136,11 @@ class ProcessMonitorTest{
                 assertEquals(evalIndividual.fitness.getHeuristic(t) , u.distance)
             }
         }
-
     }
 
     @Test
     fun testSerializedTwoStepsAndOverall(){
+        config.processFiles = "target/process_data_2s"
 
         config.enableProcessMonitor = true
         config.showProgress = true


### PR DESCRIPTION
As checked, the test failure is caused by a failure of file deletion in windows. Those files are access denied in windows for some reasons. For the moment, each test is set with a different folder to save monitor data for handling the test failure.