### PR TITLE
Basic assertions v2

### DIFF
--- a/client-java/controller/pom.xml
+++ b/client-java/controller/pom.xml
@@ -144,6 +144,11 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>compile</scope>
+        </dependency>
 
 
     </dependencies>

--- a/client-java/controller/pom.xml
+++ b/client-java/controller/pom.xml
@@ -128,6 +128,7 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -144,12 +145,6 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <scope>compile</scope>
-        </dependency>
-
 
     </dependencies>
 

--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/contentMatchers/NumberMatcher.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/contentMatchers/NumberMatcher.java
@@ -5,7 +5,7 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 
 public class NumberMatcher extends TypeSafeMatcher<Number> {
-    private double value;
+    private final double value;
 
     public NumberMatcher(double value) {
         this.value = value;
@@ -14,16 +14,19 @@ public class NumberMatcher extends TypeSafeMatcher<Number> {
     @Override
     public void describeTo(Description description) {
         //The point of the matcher is to allow comparisons between int and double that have the same valueE.g. that (int) 0 == (double) 0.0
+        description.appendValue(value);
     }
 
     @Override
     protected boolean matchesSafely (Number item) {
-        return item.doubleValue() == value;
+        if (item == null) return false;
+        else return item.doubleValue() == value;
     }
     public static Matcher<Number> numberMatches(Number item) {
         return new NumberMatcher(item.doubleValue());
     }
     public static boolean numbersMatch(Number item1, Number item2){
+        if (item1 == null || item2 == null) return false;
         NumberMatcher n1 = new NumberMatcher(item1.doubleValue());
         return n1.matchesSafely(item2);
     }

--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/contentMatchers/NumberMatcher.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/contentMatchers/NumberMatcher.java
@@ -1,0 +1,30 @@
+package org.evomaster.client.java.controller.contentMatchers;
+
+import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+public class NumberMatcher extends TypeSafeMatcher<Number> {
+    private double value;
+
+    public NumberMatcher(double value) {
+        this.value = value;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        //The point of the matcher is to allow comparisons between int and double that have the same valueE.g. that (int) 0 == (double) 0.0
+    }
+
+    @Override
+    protected boolean matchesSafely (Number item) {
+        return item.doubleValue() == value;
+    }
+    public static Matcher<Number> numberMatches(Number item) {
+        return new NumberMatcher(item.doubleValue());
+    }
+    public static boolean numbersMatch(Number item1, Number item2){
+        NumberMatcher n1 = new NumberMatcher(item1.doubleValue());
+        return n1.matchesSafely(item2);
+    }
+}

--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/expect/AggregateExpectation.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/expect/AggregateExpectation.java
@@ -4,7 +4,9 @@ public interface AggregateExpectation {
 
     //IndividualExpectation expect(Boolean active, Boolean condition);
 
-    IndividualExpectation expect();
+    AggregateExpectation expect();
+
+    AggregateExpectation expect(boolean masterSwitch);
 
     /*default IndividualExpectation expect(Boolean condition){
         return expect(false, condition);

--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/expect/ExpectationHandler.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/expect/ExpectationHandler.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 
 public class ExpectationHandler implements AggregateExpectation, IndividualExpectation {
 
+    private boolean masterSwitch = false;
     /**
      *
      * @return a DSL object to handle expectation operations.
@@ -33,27 +34,34 @@ public class ExpectationHandler implements AggregateExpectation, IndividualExpec
     private ExpectationHandler(){}
 
     @Override
-    public IndividualExpectation expect(){
+    public ExpectationHandler expect(){
+        return this;
+    }
+
+    @Override
+    public ExpectationHandler expect(boolean masterSwitch){
+        this.masterSwitch = masterSwitch;
         return this;
     }
 
     @Override
     public IndividualExpectation that(boolean active, boolean condition){
-        if(!active) return this;
-        if (!condition) throw new IllegalArgumentException("Failed Expectation Exception");
+        if(!active || !masterSwitch) return this;
+        if (!condition) { throw new AssertionError("Failed Expectation Exception"); }
         return this;
     }
 
 
     @Override
     public IndividualExpectation that(boolean active, Method method, Object[] args){
-        if (!active) return this;
+        if (!active || !masterSwitch) return this;
         else {
             try{
                 method.invoke(null, args);
             }
             catch (Exception e1){
                 //TODO: handle this somehow?
+                e1.printStackTrace();
             }
         }
         return this;

--- a/core/src/main/kotlin/org/evomaster/core/output/TestCaseWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/TestCaseWriter.kt
@@ -336,7 +336,7 @@ class TestCaseWriter {
                 }
             }
         }
-        lines.append("given()" + getAcceptHeader())
+        lines.append("given()" + getAcceptHeader(call, res))
     }
 
     private fun handleVerb(baseUrlOfSut: String, call: RestCallAction, lines: Lines) {
@@ -558,7 +558,7 @@ class TestCaseWriter {
                 }
     }
 
-    private fun getAcceptHeader(): String {
+    private fun getAcceptHeader(call: RestCallAction, res: RestCallResult): String {
         /*
          *  Note: using the type in result body is wrong:
          *  if you request a JSON but make an error, you might
@@ -566,7 +566,16 @@ class TestCaseWriter {
          *
          *  TODO: get the type from the REST call
          */
-        return ".accept(\"*/*\")"
+
+        if (call.produces.isEmpty() || res.getBodyType()==null) return ".accept(\"*/*\")"
+        //if (call.produces.contains(res.getBodyType().toString())) return ".accept(${res.getBodyType().toString()})"
+        val accepted = call.produces.filter{res.getBodyType().toString().contains(it, true)}
+
+        if (accepted.size == 1)
+            return ".accept(\"${accepted.first()}\")"
+        else
+            return ".accept(\"*/*\")  // NOTE: there seems to have been something or a problem"
+        //return ".accept(\"*/*\")"
     }
 
     private fun handleExpectations(result: RestCallResult, lines: Lines, active: Boolean){

--- a/core/src/main/kotlin/org/evomaster/core/output/TestCaseWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/TestCaseWriter.kt
@@ -389,7 +389,10 @@ class TestCaseWriter {
             when(resContentsItem::class) {
                 //Double::class -> return "anyOf(equalTo(${(Math.floor(resContentsItem as Double).toInt())}), closeTo(${(resContentsItem as Double)}, 0.1))"
                 Double::class -> return "numberMatches(${resContentsItem as Double})"
-                String::class -> return "containsString(\"${(resContentsItem as String).replace("\"", "\\\"").replace("\n", "\\n")}\")"
+                String::class -> return "containsString(\"${(resContentsItem as String)
+                        .replace("\"", "\\\"")
+                        .replace("\n", "\\n")
+                        .replace("\r", "\\r")}\")"
                 //Note: checking a string can cause (has caused) problems due to unescaped quotation marks
                 // The above solution should be refined.
                 else -> return "NotCoveredYet"
@@ -408,7 +411,8 @@ class TestCaseWriter {
 
         if(res.getBodyType()==null) lines.add(".contentType(\"\")")
         else lines.add(".contentType(\"${res.getBodyType()
-                .toString().split(";").first() //TODO this is somewhat unpleasant. A more elegant solution is needed.
+                .toString()
+                .split(";").first() //TODO this is somewhat unpleasant. A more elegant solution is needed.
         }\")")
 
         /*if(res.getBodyType()!= null && res.getStatusCode()!=500){
@@ -434,7 +438,12 @@ class TestCaseWriter {
                             resContents.forEachIndexed { index, value ->
                                 val test_i = index
                                 val printableTh = handleFieldValues(value)
-                                lines.add(".body(\"get($test_i)\", $printableTh)")
+                                if (printableTh != "null"
+                                        && printableTh != "NotCoveredYet"
+                                        && !printableTh.contains("logged")
+                                ) {
+                                    lines.add(".body(\"get($test_i)\", $printableTh)")
+                                }
                             }
                         }
                     }
@@ -604,9 +613,9 @@ class TestCaseWriter {
 
                             (resContents as LinkedTreeMap<*, *>).keys.forEach {
                                 val printableTh = handleFieldValues(resContents[it]!!)
-                                if(printableTh != "null" && printableTh != "NotCoveredYet"){
-                                    //lines.add(".body(\"${it}\", ${printableTh})")
-                                    //lines.add(".that(activeExpectations, (\"${it}\".${printableTh}))")
+                                if(printableTh != "null"
+                                        && printableTh != "NotCoveredYet"
+                                ){
                                     lines.add(".that(activeExpectations, (\"${it}\" == \"${resContents[it]}\"))")
                                 }
                             }

--- a/core/src/main/kotlin/org/evomaster/core/output/TestCaseWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/TestCaseWriter.kt
@@ -399,10 +399,10 @@ class TestCaseWriter {
             }
         }
         /* BMR: the code above is due to a somewhat unfortunate problem:
-        - Gson does parses all numbers as Double
+        - Gson parses all numbers as Double
         - Hamcrest has a hard time comparing double to int
-        This is (admittedly) a horrible hack, but it should address the issue until a more elegant solution can be found.
-        Note: it also results in an odd behaviour in the generated test: IntelliJ will complain, but the test is executable.
+        The solution is to use an additional content matcher that can be found in NumberMatcher. This can also
+        be used as a template for adding more matchers, should such a step be needed.
         * */
     }
 
@@ -414,14 +414,6 @@ class TestCaseWriter {
                 .toString()
                 .split(";").first() //TODO this is somewhat unpleasant. A more elegant solution is needed.
         }\")")
-
-        /*if(res.getBodyType()!= null && res.getStatusCode()!=500){
-            lines.add(".contentType(\"${res.getBodyType()}\")")
-        }
-
-        if(res.getStatusCode() == 500){
-            val justACheck = res.getBodyType()
-        }*/
 
         val bodyString = res.getBody()
 
@@ -476,7 +468,7 @@ class TestCaseWriter {
                         // Currently, it converts the contents to String.
                         // TODO: if the contents are not a valid form of that type, expectations should be developed to handle the case
                         //val resContents = Gson().fromJson("\"" + res.getBody() + "\"", String::class.java)
-                        //lines.add(".body(containsString(\"${resContents}\"))")
+                        lines.add(".body(containsString(\"${bodyString}\"))")
                     }
                 }
             }
@@ -631,6 +623,8 @@ class TestCaseWriter {
                         }
                         else -> {
                             // this shouldn't be run if the JSON is okay. Panic! Update: could also be null. Pause, then panic!
+                            //lines.add(".body(isEmptyOrNullString())")
+                            lines.add(".body(containsString(\"${result.getBody()}\"))")
                         }
                     }
                 }

--- a/core/src/main/kotlin/org/evomaster/core/output/service/TestSuiteWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/service/TestSuiteWriter.kt
@@ -152,7 +152,7 @@ class TestSuiteWriter {
             //addImport("org.hamcrest.core.AnyOf.anyOf", lines, true)
             addImport("io.restassured.config.JsonConfig", lines)
             addImport("io.restassured.path.json.config.JsonPathConfig", lines)
-            addImport("org.evomaster.client.java.controller.contentMatchers.NumberMatcher", lines, true)
+            addImport("org.evomaster.client.java.controller.contentMatchers.NumberMatcher.*", lines, true)
         }
 
         if(config.expectationsActive) {

--- a/core/src/main/kotlin/org/evomaster/core/problem/rest/RestActionBuilder.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/rest/RestActionBuilder.kt
@@ -54,7 +54,9 @@ class RestActionBuilder {
 
                             repairParams(params, restPath)
 
-                            val action = RestCallAction("$verb$restPath${idGenerator.incrementAndGet()}", verb, restPath, params)
+                            val produces = o.value.produces ?: mutableListOf()
+
+                            val action = RestCallAction("$verb$restPath${idGenerator.incrementAndGet()}", verb, restPath, params, produces = produces)
 
                             actionCluster.put(action.getName(), action)
                         }

--- a/core/src/main/kotlin/org/evomaster/core/problem/rest/RestActionBuilder.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/rest/RestActionBuilder.kt
@@ -54,7 +54,7 @@ class RestActionBuilder {
 
                             repairParams(params, restPath)
 
-                            val produces = o.value.produces ?: mutableListOf()
+                            val produces = o.value.produces ?: listOf()
 
                             val action = RestCallAction("$verb$restPath${idGenerator.incrementAndGet()}", verb, restPath, params, produces = produces)
 

--- a/core/src/main/kotlin/org/evomaster/core/problem/rest/RestCallAction.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/rest/RestCallAction.kt
@@ -37,7 +37,8 @@ class RestCallAction(
          * by a POST, where the POST itself might use a location for
          * path coming from a previous POST
          */
-        var locationId: String? = null
+        var locationId: String? = null,
+        var produces: MutableList<String> = mutableListOf()
 ) : RestAction {
 
     override fun shouldCountForFitnessEvaluations(): Boolean = true
@@ -46,7 +47,7 @@ class RestCallAction(
 
     override fun copy(): Action {
         val p = parameters.asSequence().map(Param::copy).toMutableList()
-        return RestCallAction(id, verb, path, p, auth, saveLocation, locationId)
+        return RestCallAction(id, verb, path, p, auth, saveLocation, locationId, produces)
     }
 
     override fun getName(): String {

--- a/core/src/main/kotlin/org/evomaster/core/problem/rest/RestCallAction.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/rest/RestCallAction.kt
@@ -38,7 +38,7 @@ class RestCallAction(
          * path coming from a previous POST
          */
         var locationId: String? = null,
-        var produces: MutableList<String> = mutableListOf()
+        var produces: List<String> = listOf()
 ) : RestAction {
 
     override fun shouldCountForFitnessEvaluations(): Boolean = true

--- a/core/src/main/kotlin/org/evomaster/core/problem/rest/service/RestFitness.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/rest/service/RestFitness.kt
@@ -319,7 +319,14 @@ class RestFitness : FitnessFunction<RestIndividual>() {
             it.replace("\"", "")
         }
 
-        val builder = client.target(fullUri).request()
+        /*
+            TODO: This only considers the first in the list of produced responses
+            This is fine for endpoints that only produce one type of response.
+            Could be a problem in future
+        */
+        val produces = a.produces.first()
+
+        val builder = client.target(fullUri).request(produces)
 
         a.auth.headers.forEach {
             builder.header(it.name, it.value)
@@ -342,6 +349,7 @@ class RestFitness : FitnessFunction<RestIndividual>() {
         /*
             TODO: need to handle "accept" of returned resource
          */
+
 
 
         val body = a.parameters.find { p -> p is BodyParam }


### PR DESCRIPTION
Some issues persist. 

1. Messages containing timestamps and/or object references cause failures.
2. Extension of Json for ProxyPrint causes some trouble. The string describing it is (in both EvoMaster and in the Api itself "application/vnd.tsdes.news+json;charset=UTF-8;version=2", but for some reason the RestAssured header reads "application/vnd.tsdes.news+json; version=2;charset=UTF-8". The reversal of charset and version appears to cause the problems. 