### PR TITLE
Use template when location fails parsing

### DIFF
--- a/client-java/controller-api/src/main/java/org/evomaster/client/java/controller/api/EMTestUtils.java
+++ b/client-java/controller-api/src/main/java/org/evomaster/client/java/controller/api/EMTestUtils.java
@@ -37,7 +37,7 @@ public class EMTestUtils {
         try{
             locationURI = URI.create(locationHeader);
         } catch (Exception e){
-            return expectedTemplate;
+            return locationHeader;
         }
         String locationPath = locationURI.getPath();
         String[] locationTokens = locationPath.split("/");

--- a/client-java/controller-api/src/main/java/org/evomaster/client/java/controller/api/EMTestUtils.java
+++ b/client-java/controller-api/src/main/java/org/evomaster/client/java/controller/api/EMTestUtils.java
@@ -37,7 +37,7 @@ public class EMTestUtils {
         try{
             locationURI = URI.create(locationHeader);
         } catch (Exception e){
-            return locationHeader;
+            return expectedTemplate;
         }
         String locationPath = locationURI.getPath();
         String[] locationTokens = locationPath.split("/");

--- a/client-java/controller-api/src/test/java/org/evomaster/client/java/controller/api/EMTestUtilsTest.java
+++ b/client-java/controller-api/src/test/java/org/evomaster/client/java/controller/api/EMTestUtilsTest.java
@@ -54,7 +54,7 @@ public class EMTestUtilsTest {
 
         String resolvedLocation = EMTestUtils.resolveLocation(locationHeader, expectedTemplate);
 
-        assertEquals(expectedTemplate, resolvedLocation);
+        assertEquals(locationHeader, resolvedLocation);
     }
 
     @Test

--- a/client-java/controller-api/src/test/java/org/evomaster/client/java/controller/api/EMTestUtilsTest.java
+++ b/client-java/controller-api/src/test/java/org/evomaster/client/java/controller/api/EMTestUtilsTest.java
@@ -1,8 +1,10 @@
 package org.evomaster.client.java.controller.api;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 public class EMTestUtilsTest {
 
@@ -43,6 +45,16 @@ public class EMTestUtilsTest {
 
         String res = EMTestUtils.resolveLocation(location, template);
         assertEquals(template, res);
+    }
+
+    @Test
+    public void givenAnInvalidLocationHeaderWhenResolveLocationThenTheExpectedTemplateIsReturned() {
+        String expectedTemplate = "http://localhost:12345/a/x";
+        String locationHeader = "/a/\"52\"";
+
+        String resolvedLocation = EMTestUtils.resolveLocation(locationHeader, expectedTemplate);
+
+        assertEquals(expectedTemplate, resolvedLocation);
     }
 
     @Test

--- a/core/src/main/kotlin/org/evomaster/core/problem/rest/RestCallResult.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/rest/RestCallResult.kt
@@ -1,5 +1,6 @@
 package org.evomaster.core.problem.rest
 
+import com.google.common.annotations.VisibleForTesting
 import com.google.gson.Gson
 import com.google.gson.JsonObject
 import org.evomaster.core.search.ActionResult
@@ -9,7 +10,8 @@ import javax.ws.rs.core.MediaType
 class RestCallResult : ActionResult {
 
     constructor(stopping: Boolean = false) : super(stopping)
-    private constructor(other: ActionResult) : super(other)
+    @VisibleForTesting
+    internal constructor(other: ActionResult) : super(other)
 
     companion object {
         const val STATUS_CODE = "STATUS_CODE"
@@ -53,7 +55,7 @@ class RestCallResult : ActionResult {
                     TODO: "id" is the most common word, but could check
                     if others are used as well.
                  */
-                Gson().fromJson(it, JsonObject::class.java).get(getResourceIdName())?.toString()
+                Gson().fromJson(it, JsonObject::class.java).get(getResourceIdName())?.asString
             } catch (e: Exception){
                 //nothing to do
                 null

--- a/core/src/test/kotlin/org/evomaster/core/problem/rest/RestCallResultTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/problem/rest/RestCallResultTest.kt
@@ -1,0 +1,29 @@
+package org.evomaster.core.problem.rest
+
+import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Test
+import javax.ws.rs.core.MediaType
+
+internal class RestCallResultTest {
+
+    @Test
+    fun givenAStringIdWhenGetResourceIdThenItIsReturnedAsString() {
+        val rc = RestCallResult(false)
+        rc.setBody("{\"id\":\"735\"}")
+        rc.setBodyType(MediaType.APPLICATION_JSON_TYPE)
+
+        val res = rc.getResourceId()
+
+        assertEquals("735", res)
+    }
+    @Test
+    fun givenANumericIdWhenGetResourceIdThenItIsReturnedAsString() {
+        val rc = RestCallResult(false)
+        rc.setBody("{\"id\":735}")
+        rc.setBodyType(MediaType.APPLICATION_JSON_TYPE)
+
+        val res = rc.getResourceId()
+
+        assertEquals("735", res)
+    }
+}


### PR DESCRIPTION
I found that:

## Get Resource Id
- When a resource ID was a string, then when calling the `getResourceId` method to generate the Location Header, then it was incorrectly parsed as it escaped the char `"`. For example if the payload is:
```
{ "id": "aStringId" }
```
Then, the resource id of the response was: `"\"aStringId\""`.

That resulted into generating a wrong location header, for example: `/v0/"aStringId"`. So it failed when trying to parse it as a URI in `resolveLocation`

## Resolve Location
- When a Location Header can not be parsed into a URI, then instead of returning the expected template the invalid location was returned. This caused making requests to an invalid URL and made Evomaster to stop running. 