### PR TITLE
Fix all failing tests on macOS Catalina with Spanish locale

### DIFF
--- a/client-java/controller/pom.xml
+++ b/client-java/controller/pom.xml
@@ -145,6 +145,11 @@
             <artifactId>testcontainers</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>

--- a/client-java/instrumentation/src/test/java/org/evomaster/client/java/instrumentation/coverage/methodreplacement/classes/CollectionClassReplacementTest.java
+++ b/client-java/instrumentation/src/test/java/org/evomaster/client/java/instrumentation/coverage/methodreplacement/classes/CollectionClassReplacementTest.java
@@ -220,7 +220,7 @@ public class CollectionClassReplacementTest {
 
         String format = "MM/dd/yyyy hh:mm a";
 
-        SimpleDateFormat sdf = new SimpleDateFormat(format);
+        SimpleDateFormat sdf = new SimpleDateFormat(format, Locale.ENGLISH);
 
         Date dateTime1 = sdf.parse(date1 + " " + time1);
         Date dateTime2 = sdf.parse(date1 + " " + time2);

--- a/client-java/instrumentation/src/test/java/org/evomaster/client/java/instrumentation/coverage/methodreplacement/classes/DateClassReplacementTest.java
+++ b/client-java/instrumentation/src/test/java/org/evomaster/client/java/instrumentation/coverage/methodreplacement/classes/DateClassReplacementTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -92,7 +93,7 @@ public class DateClassReplacementTest {
 
         String format = "MM/dd/yyyy hh:mm a";
 
-        SimpleDateFormat sdf = new SimpleDateFormat(format);
+        SimpleDateFormat sdf = new SimpleDateFormat(format, Locale.ENGLISH);
 
         Date dateTime1 = sdf.parse(date1 + " " + time1);
         Date dateTime2 = sdf.parse(date1 + " " + time2);
@@ -118,7 +119,7 @@ public class DateClassReplacementTest {
 
         String format = "MM/dd/yyyy hh:mm a";
 
-        SimpleDateFormat sdf = new SimpleDateFormat(format);
+        SimpleDateFormat sdf = new SimpleDateFormat(format, Locale.ENGLISH);
 
         Date dateObject1 = sdf.parse(date1 + " " + time1);
         Date dateObject2 = sdf.parse(date1 + " " + time2);
@@ -153,7 +154,7 @@ public class DateClassReplacementTest {
 
         String format = "MM/dd/yyyy hh:mm a";
 
-        SimpleDateFormat sdf = new SimpleDateFormat(format);
+        SimpleDateFormat sdf = new SimpleDateFormat(format, Locale.ENGLISH);
 
         Date dateObject1 = sdf.parse(date1 + " " + time1);
         Date dateObject2 = sdf.parse(date1 + " " + time2);
@@ -196,7 +197,7 @@ public class DateClassReplacementTest {
 
         String format = "MM/dd/yyyy hh:mm a";
 
-        SimpleDateFormat sdf = new SimpleDateFormat(format);
+        SimpleDateFormat sdf = new SimpleDateFormat(format, Locale.ENGLISH);
 
         Date dateObject1 = sdf.parse(date1 + " " + time1);
         Date dateObject2 = sdf.parse(date1 + " " + time2);
@@ -220,7 +221,7 @@ public class DateClassReplacementTest {
 
         String format = "MM/dd/yyyy hh:mm a";
 
-        SimpleDateFormat sdf = new SimpleDateFormat(format);
+        SimpleDateFormat sdf = new SimpleDateFormat(format, Locale.ENGLISH);
 
         Date dateObject1 = sdf.parse(date1 + " " + time1);
         Date dateObject2 = sdf.parse(date1 + " " + time2);
@@ -242,7 +243,7 @@ public class DateClassReplacementTest {
 
         String format = "MM/dd/yyyy hh:mm a";
 
-        SimpleDateFormat sdf = new SimpleDateFormat(format);
+        SimpleDateFormat sdf = new SimpleDateFormat(format, Locale.ENGLISH);
 
         Date dateTime = sdf.parse(date1 + " " + time1);
 
@@ -260,7 +261,7 @@ public class DateClassReplacementTest {
 
         String format = "MM/dd/yyyy hh:mm a";
 
-        SimpleDateFormat sdf = new SimpleDateFormat(format);
+        SimpleDateFormat sdf = new SimpleDateFormat(format, Locale.ENGLISH);
 
         Date dateTime = sdf.parse(date1 + " " + time1);
 
@@ -279,7 +280,7 @@ public class DateClassReplacementTest {
 
         String format = "MM/dd/yyyy hh:mm a";
 
-        SimpleDateFormat sdf = new SimpleDateFormat(format);
+        SimpleDateFormat sdf = new SimpleDateFormat(format, Locale.ENGLISH);
 
         Date dateTime = sdf.parse(date1 + " " + time1);
 

--- a/client-java/instrumentation/src/test/java/org/evomaster/client/java/instrumentation/coverage/methodreplacement/classes/ObjectsClassReplacementTest.java
+++ b/client-java/instrumentation/src/test/java/org/evomaster/client/java/instrumentation/coverage/methodreplacement/classes/ObjectsClassReplacementTest.java
@@ -12,6 +12,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Date;
+import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -116,7 +117,7 @@ public class ObjectsClassReplacementTest {
 
         String format = "MM/dd/yyyy hh:mm a";
 
-        SimpleDateFormat sdf = new SimpleDateFormat(format);
+        SimpleDateFormat sdf = new SimpleDateFormat(format, Locale.ENGLISH);
 
         Date dateObject1 = sdf.parse(date1 + " " + time1);
         Date dateObject2 = sdf.parse(date1 + " " + time2);

--- a/client-java/instrumentation/src/test/java/org/evomaster/client/java/instrumentation/example/methodreplacement/TestabilityExcInstrumentedTest.java
+++ b/client-java/instrumentation/src/test/java/org/evomaster/client/java/instrumentation/example/methodreplacement/TestabilityExcInstrumentedTest.java
@@ -162,7 +162,7 @@ public class TestabilityExcInstrumentedTest {
 
         TestabilityExc te = getInstance();
 
-        SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy hh:mm a");
+        SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy hh:mm a", Locale.ENGLISH);
         Date dateInstance1 = sdf.parse("07/15/2016 11:00 AM");
         Date dateInstance2 = sdf.parse("07/15/2016 11:15 AM");
 
@@ -200,7 +200,7 @@ public class TestabilityExcInstrumentedTest {
 
         TestabilityExc te = getInstance();
 
-        SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy hh:mm a");
+        SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy hh:mm a", Locale.ENGLISH);
         Date dateInstance1 = sdf.parse("07/15/2016 11:00 AM");
         Date dateInstance2 = sdf.parse("07/15/2016 11:15 AM");
 
@@ -238,7 +238,7 @@ public class TestabilityExcInstrumentedTest {
 
         TestabilityExc te = getInstance();
 
-        SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy hh:mm a");
+        SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy hh:mm a", Locale.ENGLISH);
         Date dateInstance1 = sdf.parse("07/15/2016 11:00 AM");
         Date dateInstance2 = sdf.parse("07/15/2016 11:15 AM");
         Date dateInstance3 = sdf.parse("07/15/2016 11:30 AM");

--- a/pom.xml
+++ b/pom.xml
@@ -110,9 +110,9 @@
         <jersey.version>2.29.1</jersey.version>
         <javax.el.version>2.2.5</javax.el.version>
         <jackson.version>2.11.0</jackson.version>
-<!--        <springweb.version>5.3.1</springweb.version>-->
         <asm.version>8.0.1</asm.version>
-        <testcontainers.version>1.14.3</testcontainers.version>
+        <testcontainers.version>1.15.0</testcontainers.version>
+        <jetbrains.annotations.version>20.1.0</jetbrains.annotations.version>
         <antlr.version>4.7.2</antlr.version>
         <nlp.version>3.9.2</nlp.version>
         <dk.brics.automaton.version>1.11-8</dk.brics.automaton.version>
@@ -616,6 +616,13 @@
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers</artifactId>
                 <version>${testcontainers.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <!-- Used in SqlHandlerInDBTest class -->
+                <groupId>org.jetbrains</groupId>
+                <artifactId>annotations</artifactId>
+                <version>${jetbrains.annotations.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
Additional changes:
- Updated testcontainers to 1.15.0 because some tests were failing due to this: https://github.com/testcontainers/testcontainers-java/issues/3166
- testcontainers 1.15.0 does not include org.jetbrains.annotations as a mvn dependency, which is used in class SqlHandlerInDBTest. Added such dependency.