### PR TITLE
Looking up the path can be problematic. In the case of language tools…

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/output/oracles/ImplementedOracle.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/oracles/ImplementedOracle.kt
@@ -82,6 +82,8 @@ abstract class ImplementedOracle {
     fun retrievePath(objectGenerator: ObjectGenerator, call: RestCallAction): PathItem? {
         return objectGenerator.getSwagger().paths.get(call.path.toString()) ?:
         objectGenerator.getSwagger().paths.get(call.path.toString().removePrefix("/api")) ?:
-        objectGenerator.getSwagger().paths.get(call.path.toString().removePrefix("/v2"))
+        objectGenerator.getSwagger().paths.get(call.path.toString().removePrefix("/v2")) ?:
+        objectGenerator.getSwagger().paths.get(call.path.toString().removePrefix("/v1"))
+
     }
 }

--- a/core/src/main/kotlin/org/evomaster/core/output/oracles/ImplementedOracle.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/oracles/ImplementedOracle.kt
@@ -75,9 +75,13 @@ abstract class ImplementedOracle {
      * This is a workaround (ScoutAPI only sees paths without the prefix, others with the prefix).
      * Longer term, this could also be a place to handle any additional peculiarities with SUT specific
      * OpenAPI standards.
+     *
+     * The same applies where the prefix is "v2" (e.g. language tools).
      */
+
     fun retrievePath(objectGenerator: ObjectGenerator, call: RestCallAction): PathItem? {
         return objectGenerator.getSwagger().paths.get(call.path.toString()) ?:
-        objectGenerator.getSwagger().paths.get(call.path.toString().removePrefix("/api"))
+        objectGenerator.getSwagger().paths.get(call.path.toString().removePrefix("/api")) ?:
+        objectGenerator.getSwagger().paths.get(call.path.toString().removePrefix("/v2"))
     }
 }


### PR DESCRIPTION
When looking up the supported responses (and respective code), the OpenAPI specification sometimes excludes some prefixes. 

In the case of Language tools, this was "/v2". 
Other APIs may have different prefixes that need exclusion. 

The approach at the moment is to try to get the path as is. If null, try to remove common prefixes until a non-null path is found (or we run out of common prefixes). 

This should solve the problem for the moment, though a long term solution might still be needed. 