### PR TITLE
Clustering bugfix

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/Main.kt
+++ b/core/src/main/kotlin/org/evomaster/core/Main.kt
@@ -359,7 +359,7 @@ class Main {
                     " Used experimental settings: $options")
         }
 
-        private fun checkState(injector: Injector): ControllerInfoDto? {
+         fun checkState(injector: Injector): ControllerInfoDto? {
 
             val config = injector.getInstance(EMConfig::class.java)
 
@@ -386,7 +386,7 @@ class Main {
         }
 
 
-        private fun writeTests(injector: Injector, solution: Solution<*>, controllerInfoDto: ControllerInfoDto?) {
+         fun writeTests(injector: Injector, solution: Solution<*>, controllerInfoDto: ControllerInfoDto?) {
 
             val config = injector.getInstance(EMConfig::class.java)
 

--- a/core/src/main/kotlin/org/evomaster/core/output/Clusterer.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/Clusterer.kt
@@ -49,6 +49,12 @@ object Clusterer {
         }.map { ac -> ac.result }
                 .filterIsInstance<HttpWsCallResult>()
 
+        //TODO: Check the clusterableActions here.
+        // if clusterableActions are comprised of results that are not HttpWsCallResult.
+        // Currently it throws an exception. But what would be the expected behaviour? Presumably, as clustering is
+        // not guaranteed, return without clusters? or introduce the checks earlier?
+
+        //BMR: Could it be that clusterableACtions are null here (I mean... it could).
         val clu = DBSCANClusterer<HttpWsCallResult>(
                 values = clusterableActions,
                 epsilon = epsilon,

--- a/core/src/main/kotlin/org/evomaster/core/output/TestSuiteSplitter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/TestSuiteSplitter.kt
@@ -68,10 +68,17 @@ object TestSuiteSplitter {
             }
         }.toMutableList()
 
+        val clusterableActions = errs.flatMap {
+            it.evaluatedActions().filter { ac ->
+                TestSuiteSplitter.assessFailed(ac, oracles)
+            }
+        }.map { ac -> ac.result }
+                .filterIsInstance<HttpWsCallResult>()
+
         // If no individuals have a failed result, the summary is empty
         // If only one individual has a failed result, clustering is skipped, and the relevant individual is returned
 
-        when (errs.size) {
+        when (clusterableActions.size) {
             0 -> splitResult.splitOutcome = mutableListOf()
             1 -> splitResult.splitOutcome = mutableListOf(Solution(errs, solution.testSuiteNamePrefix, solution.testSuiteNameSuffix, Termination.SUMMARY))
         }

--- a/e2e-tests/e2e-tests-utils/src/test/java/org/evomaster/e2etests/utils/WsTestBase.java
+++ b/e2e-tests/e2e-tests-utils/src/test/java/org/evomaster/e2etests/utils/WsTestBase.java
@@ -157,7 +157,7 @@ public abstract class WsTestBase {
             for (String termination : terminations) {
                 classNames.add(new ClassName(fullClassName + termination));
             }
-            splitType = "CODE";
+            splitType = "CLUSTER";
         }
 
          /*

--- a/e2e-tests/spring-rest-openapi-v3/src/main/kotlin/com/foo/rest/examples/spring/openapi/v3/cluster/ClusterApplication.kt
+++ b/e2e-tests/spring-rest-openapi-v3/src/main/kotlin/com/foo/rest/examples/spring/openapi/v3/cluster/ClusterApplication.kt
@@ -1,6 +1,5 @@
-package com.foo.rest.examples.spring.openapi.v3.expectations
+package com.foo.rest.examples.spring.openapi.v3.cluster
 
-import com.foo.rest.examples.spring.openapi.v3.base.BaseApplication
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
@@ -12,28 +11,24 @@ import java.lang.IllegalArgumentException
 
 
 @SpringBootApplication(exclude = [SecurityAutoConfiguration::class])
-@RequestMapping(path = ["/api/expectations"])
-open class ExpectationsApplication {
+@RequestMapping(path = ["/api/cluster"])
+open class ClusterApplication {
     companion object {
         @JvmStatic
         fun main(args: Array<String>) {
-            SpringApplication.run(ExpectationsApplication::class.java, *args)
+            SpringApplication.run(ClusterApplication::class.java, *args)
         }
     }
 
-    @GetMapping(path = ["/{success}"])
+    @GetMapping(path = ["/path1/{success}"])
     open fun get(@PathVariable("success") success: Boolean) : ResponseEntity<String> {
         if (success) return ResponseEntity.ok("Hello World!!!")
         else throw IllegalArgumentException("Failed Call")
     }
 
-    @GetMapping(path = ["/time/{out}"])
-    open fun timeout(@PathVariable("out") out: Boolean) : ResponseEntity<String> {
-        if (out) return ResponseEntity.ok("And about!")
-        else {
-            //TODO: The idea was to use this for assessing variable generation with timed out calls. Doesn't seem to work properly.
-            // Thread.sleep(6000)
-            return ResponseEntity.status(408).build()
-        }
+    @GetMapping(path = ["/path2/{success}"])
+    open fun timeout(@PathVariable("success") success: Boolean) : ResponseEntity<String> {
+        if (success) return ResponseEntity.ok("Hullo Again!")
+        else throw IllegalArgumentException("Failed Call")
     }
 }

--- a/e2e-tests/spring-rest-openapi-v3/src/test/kotlin/com/foo/rest/examples/spring/openapi/v3/cluster/ClusterTestController.kt
+++ b/e2e-tests/spring-rest-openapi-v3/src/test/kotlin/com/foo/rest/examples/spring/openapi/v3/cluster/ClusterTestController.kt
@@ -1,0 +1,6 @@
+package com.foo.rest.examples.spring.openapi.v3.cluster
+
+import com.foo.rest.examples.spring.openapi.v3.SpringController
+
+class ClusterTestController : SpringController(ClusterApplication::class.java) {
+}

--- a/e2e-tests/spring-rest-openapi-v3/src/test/kotlin/com/foo/rest/examples/spring/openapi/v3/expectations/ExpectationsController.kt
+++ b/e2e-tests/spring-rest-openapi-v3/src/test/kotlin/com/foo/rest/examples/spring/openapi/v3/expectations/ExpectationsController.kt
@@ -1,6 +1,0 @@
-package com.foo.rest.examples.spring.openapi.v3.expectations
-
-import com.foo.rest.examples.spring.openapi.v3.SpringController
-
-class ExpectationsController : SpringController(ExpectationsApplication::class.java) {
-}

--- a/e2e-tests/spring-rest-openapi-v3/src/test/kotlin/org/evomaster/e2etests/spring/openapi/v3/cluster/ClusterEMTest.kt
+++ b/e2e-tests/spring-rest-openapi-v3/src/test/kotlin/org/evomaster/e2etests/spring/openapi/v3/cluster/ClusterEMTest.kt
@@ -1,33 +1,37 @@
 package org.evomaster.e2etests.spring.openapi.v3.examples.expectations
 
-import com.foo.rest.examples.spring.openapi.v3.expectations.ExpectationsController
+import com.foo.rest.examples.spring.openapi.v3.cluster.ClusterTestController
 import io.restassured.RestAssured.given
+import org.evomaster.core.EMConfig
+import org.evomaster.core.Main
 import org.evomaster.core.problem.rest.HttpVerb
+import org.evomaster.core.problem.rest.RestIndividual
+import org.evomaster.core.search.Solution
 import org.evomaster.e2etests.spring.openapi.v3.SpringTestBase
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 
-class ExpectationsEMTest : SpringTestBase() {
+class ClusterEMTest : SpringTestBase() {
     //TODO: BMR - more expectations related tests are possible. This is a good place for them.
 
     companion object {
         @BeforeAll
         @JvmStatic
         fun init() {
-            initClass(ExpectationsController())
+            initClass(ClusterTestController())
         }
     }
 
     @Test
     fun testRunManual(){
         given().accept("*/*")
-                .get(baseUrlOfSut + "/api/expectations/" + true)
+                .get(baseUrlOfSut + "/api/cluster/path1/" + true)
                 .then()
                 .statusCode(200)
 
         given().accept("*/*")
-                .get(baseUrlOfSut + "/api/expectations/" + false)
+                .get(baseUrlOfSut + "/api/cluster/path2/" + false)
                 .then()
                 .statusCode(500)
 
@@ -35,11 +39,24 @@ class ExpectationsEMTest : SpringTestBase() {
 
     @Test
     fun testRunEM(){
+
+        val terminations = listOf("_faults", "_successes")
+
         runTestHandlingFlakyAndCompilation(
-                "ExpectationsEM",
-                "org.foo.ExpectationsEM",
+                "ClusterEM",
+                "org.foo.ClusterEM",
+                terminations,
                 100
         ){args: MutableList<String> ->
+
+            /*
+            val injector = Main.init(args.toTypedArray())
+
+            val config = injector.getInstance(EMConfig::class.java)
+            config.testSuiteSplitType = EMConfig.TestSuiteSplitType.CLUSTER
+
+            val solution = Main.run(injector) as Solution<RestIndividual>
+*/
 
             val solution = initAndRun(args)
 

--- a/e2e-tests/spring-rest-openapi-v3/src/test/kotlin/org/evomaster/e2etests/spring/openapi/v3/cluster/ClusterEMTest.kt
+++ b/e2e-tests/spring-rest-openapi-v3/src/test/kotlin/org/evomaster/e2etests/spring/openapi/v3/cluster/ClusterEMTest.kt
@@ -78,8 +78,8 @@ class ClusterEMTest : SpringTestBase() {
 
         val terminations = listOf("_faults", "_successes")
         runTestHandlingFlakyAndCompilation(
-                "ClusterEM",
-                "org.foo.ClusterEM",
+                "ClusterEMTypeBug",
+                "org.foo.ClusterEMTypeBug",
                 terminations,
                 100
         ){args: MutableList<String> ->


### PR DESCRIPTION
I suspect the problem is that the initial filtering (when deciding whether or not clustering can be performed) assumed (rather than checked) that the Results are HttpWsActionResults. When they are not, the DBSCANClusterer attempts to perform clustering, but fails and crashes. An extra check has been added to remedy this. 

I don't have a way of replicating the problem for the moment, but I did put into place a bit of scaffolding for a future test (once I'm able to replicate the problem). Alternatively it can be removed if it turns out to be useless. 

I've made minor modifications to the visibility of a couple of methods in Main (writeTests and checkState) to allow me to edit the default EMConfig values from the defaults given by init(). 