### PR TITLE
Objectgenerator fault

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/output/ObjectGenerator.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/ObjectGenerator.kt
@@ -86,8 +86,18 @@ class ObjectGenerator {
         }
     }
 
+    /**
+     * [getNamedReference] returns the ObjectGene with the matching name from the model cluster.
+     * It is meant to be used in conjunction with [containsKey], to check if the key is present and define appropriate
+     * behaviour if it is not present.
+     * If [getNamedReference] is called with a string key that is not contained in the model cluster, the default
+     * behaviour is to return an empty ObjectGene with the name "NotFound".
+     */
     fun getNamedReference(name: String): ObjectGene{
-        return modelCluster.getValue(name)
+        return when{
+            containsKey(name) -> modelCluster.getValue(name)
+            else -> ObjectGene("NotFound", listOf())
+        }
     }
     fun containsKey(name: String): Boolean{
         return modelCluster.containsKey(name)


### PR DESCRIPTION
Adjusted the reference lookup to avoid the crash. 

Updated how the basic types (especially "object") are handled: an object of the basic type "object" no longer generates an "empty" (i.e. without content), since the type "object" makes no assumptions about structure.

Added an extra bit of safety, the ObjectGenerator.kt returns an empty ObjectGene with the name "NotFound" (added a quick clarification as well).