### PR TITLE
fix a bug in js assertion for 'null' value

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/output/service/HttpWsTestCaseWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/service/HttpWsTestCaseWriter.kt
@@ -635,7 +635,7 @@ abstract class HttpWsTestCaseWriter : WebTestCaseWriter() {
         if (value == null) {
             val instruction = when {
                 format.isJavaOrKotlin() -> ".body(\"${fieldPath}\", nullValue())"
-                format.isJavaScript() -> "expect($responseVariableName$fieldPath).toBe(null);"
+                format.isJavaScript() -> "expect($responseVariableName.body$fieldPath).toBe(null);"
                 format.isCsharp() -> "Assert.True($responseVariableName$fieldPath == null);"
                 else -> throw IllegalStateException("Format not supported yet: $format")
             }


### PR DESCRIPTION
it should be `res.body.property` but `body` is missing.