### PR TITLE
handle replaced ternary with await

### DIFF
--- a/client-js/evomaster-client-js/src/instrumentation/babel-plugin-evomaster.ts
+++ b/client-js/evomaster-client-js/src/instrumentation/babel-plugin-evomaster.ts
@@ -369,8 +369,10 @@ export default function evomasterPlugin(
             additional branch will be added there.
 
          */
-        const consequent = t.arrowFunctionExpression([], exp.consequent, doesContainAwaitExpression(exp.consequent));
-        const alternate = t.arrowFunctionExpression([], exp.alternate, doesContainAwaitExpression(exp.alternate));
+        const consequentIsAwait = doesContainAwaitExpression(exp.consequent)
+        const consequent = t.arrowFunctionExpression([], exp.consequent, consequentIsAwait);
+        const alternateIsAwait = doesContainAwaitExpression(exp.alternate)
+        const alternate = t.arrowFunctionExpression([], exp.alternate, alternateIsAwait);
 
 
         objectives.push(ObjectiveNaming.statementObjectiveName(fileName, l, statementCounter));
@@ -379,6 +381,11 @@ export default function evomasterPlugin(
             [consequent,
                 t.stringLiteral(fileName), t.numericLiteral(l), t.numericLiteral(statementCounter)]
         );
+
+        if (consequentIsAwait)
+            exp.consequent = t.awaitExpression(exp.consequent);
+
+
         statementCounter++;
 
         objectives.push(ObjectiveNaming.statementObjectiveName(fileName, l, statementCounter));
@@ -387,6 +394,10 @@ export default function evomasterPlugin(
             [alternate,
                 t.stringLiteral(fileName), t.numericLiteral(l), t.numericLiteral(statementCounter)]
         );
+
+        if (alternateIsAwait)
+            exp.alternate = t.awaitExpression(exp.alternate);
+
         statementCounter++;
     }
 

--- a/client-js/evomaster-client-js/tests/unit/instrumentation/babel-code-test.ts
+++ b/client-js/evomaster-client-js/tests/unit/instrumentation/babel-code-test.ts
@@ -791,7 +791,7 @@ test("ternary with await expression", async () => {
         f = async function (x) {
           __EM__.enteringStatement("test.ts", 2, 1);
         
-          return __EM__.completingStatement(__EM__.cmp(x, ">", 0, "test.ts", 2, 0) ? __EM__.ternary(async () => await new Promise(resolve => __EM__.callBase(() => resolve(1))), "test.ts", 2, 2) : __EM__.ternary(async () => await new Promise(resolve => __EM__.callBase(() => resolve(2))), "test.ts", 2, 3), "test.ts", 2, 1);
+          return __EM__.completingStatement(__EM__.cmp(x, ">", 0, "test.ts", 2, 0) ? await __EM__.ternary(async () => await new Promise(resolve => __EM__.callBase(() => resolve(1))), "test.ts", 2, 2) : await __EM__.ternary(async () => await new Promise(resolve => __EM__.callBase(() => resolve(2))), "test.ts", 2, 3), "test.ts", 2, 1);
         };
         
         __EM__.completedStatement("test.ts", 1, 0);
@@ -863,7 +863,7 @@ test("embedded await expression", async () => {
         async function afoo(x) {
           __EM__.enteringStatement("test.ts", 2, 1);
         
-          return __EM__.completingStatement(__EM__.cmp(x, ">", 5, "test.ts", 2, 0) ? __EM__.ternary(async () => await new Promise(resolve => __EM__.callBase(() => resolve(x - 1))), "test.ts", 2, 2) : __EM__.ternary(async () => await new Promise(resolve => __EM__.callBase(() => resolve(x + 1))), "test.ts", 2, 3), "test.ts", 2, 1);
+          return __EM__.completingStatement(__EM__.cmp(x, ">", 5, "test.ts", 2, 0) ? await __EM__.ternary(async () => await new Promise(resolve => __EM__.callBase(() => resolve(x - 1))), "test.ts", 2, 2) : await __EM__.ternary(async () => await new Promise(resolve => __EM__.callBase(() => resolve(x + 1))), "test.ts", 2, 3), "test.ts", 2, 1);
         }
         
         __EM__.completedStatement("test.ts", 1, 0);
@@ -883,7 +883,7 @@ test("embedded await expression", async () => {
         f = async function (x) {
           __EM__.enteringStatement("test.ts", 12, 7);
         
-          return __EM__.completingStatement(__EM__.cmp((await __EM__.callBase(() => afoo(x))), ">", 5, "test.ts", 12, 2) ? __EM__.ternary(async () => __EM__.callBase(async () => numToString((await __EM__.callBase(() => afoo(x - 1))))), "test.ts", 12, 8) : __EM__.ternary(async () => __EM__.callBase(async () => numToString((await __EM__.callBase(() => afoo(x + 1))))), "test.ts", 12, 9), "test.ts", 12, 7);
+          return __EM__.completingStatement(__EM__.cmp((await __EM__.callBase(() => afoo(x))), ">", 5, "test.ts", 12, 2) ? await __EM__.ternary(async () => __EM__.callBase(async () => numToString((await __EM__.callBase(() => afoo(x - 1))))), "test.ts", 12, 8) : await __EM__.ternary(async () => __EM__.callBase(async () => numToString((await __EM__.callBase(() => afoo(x + 1))))), "test.ts", 12, 9), "test.ts", 12, 7);
         };
         
         __EM__.completedStatement("test.ts", 11, 6);
@@ -914,7 +914,7 @@ test("disease sut", () => {
         async function afoo(key, lastdays) {
           __EM__.enteringStatement("test.ts", 2, 1);
         
-          (await __EM__.callTracked("test.ts", 2, 0, redis, "hexists", key, lastdays)) ? __EM__.ternary(async () => parsedData = __EM__.callTracked("test.ts", 3, 1, JSON, "parse", (await __EM__.callTracked("test.ts", 3, 2, redis, "hget", key, lastdays))), "test.ts", 2, 2) : __EM__.ternary(async () => parsedData = __EM__.callTracked("test.ts", 4, 3, JSON, "parse", (await __EM__.callTracked("test.ts", 4, 4, redis, "hget", key, 'data'))), "test.ts", 2, 3);
+          (await __EM__.callTracked("test.ts", 2, 0, redis, "hexists", key, lastdays)) ? await __EM__.ternary(async () => parsedData = __EM__.callTracked("test.ts", 3, 1, JSON, "parse", (await __EM__.callTracked("test.ts", 3, 2, redis, "hget", key, lastdays))), "test.ts", 2, 2) : await __EM__.ternary(async () => parsedData = __EM__.callTracked("test.ts", 4, 3, JSON, "parse", (await __EM__.callTracked("test.ts", 4, 4, redis, "hget", key, 'data'))), "test.ts", 2, 3);
         
           __EM__.completedStatement("test.ts", 2, 1);
         }
@@ -959,7 +959,7 @@ test("await in the inputs params", ()=>{
         async function afoo(x) {
           __EM__.enteringStatement("test.ts", 2, 1);
         
-          return __EM__.completingStatement(__EM__.cmp(x, ">", 5, "test.ts", 2, 0) ? __EM__.ternary(async () => await new Promise(resolve => __EM__.callBase(() => resolve(x - 1))), "test.ts", 2, 2) : __EM__.ternary(async () => await new Promise(resolve => __EM__.callBase(() => resolve(x + 1))), "test.ts", 2, 3), "test.ts", 2, 1);
+          return __EM__.completingStatement(__EM__.cmp(x, ">", 5, "test.ts", 2, 0) ? await __EM__.ternary(async () => await new Promise(resolve => __EM__.callBase(() => resolve(x - 1))), "test.ts", 2, 2) : await __EM__.ternary(async () => await new Promise(resolve => __EM__.callBase(() => resolve(x + 1))), "test.ts", 2, 3), "test.ts", 2, 1);
         }
         
         __EM__.completedStatement("test.ts", 1, 0);


### PR DESCRIPTION
if the expression in ternary is `await`, EM.ternary is also required to be with `await`