### PR TITLE
fix a bug when adding auth for bb

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/problem/rest/service/BlackBoxRestFitness.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/rest/service/BlackBoxRestFitness.kt
@@ -38,8 +38,8 @@ class BlackBoxRestFitness : RestFitness() {
                 ie, bbExperiments is enabled.
                 TODO might support other manner to configure auth for bb
              */
-            cookies.plus(getCookies(individual))
-            tokens.plus(getTokens(individual))
+            cookies.putAll(getCookies(individual))
+            tokens.putAll(getTokens(individual))
         }
 
         val fv = FitnessValue(individual.size().toDouble())


### PR DESCRIPTION
the bug was introduced when I put the auth within bbexp that does not affect the experiment.
As checked, the exp was started before the branch was merged, and tokens are correctly obtained in tests with bb settings.