### PR TITLE
Rpc test generations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,7 @@ experiments/target/
 
 /client-js/integration-tests/build/
 /core-it/target/
-/coveredTargets.txt
+/coveredTargets_1.txt
 /core-driver-it/target/
 /core-it/src/test/kotlin/exp/
 

--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,7 @@ experiments/target/
 
 /client-js/integration-tests/build/
 /core-it/target/
-/coveredTargets_1.txt
+/coveredTargets.txt
 /core-driver-it/target/
 /core-it/src/test/kotlin/exp/
 

--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/problem/rpc/CodeJavaGenerator.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/problem/rpc/CodeJavaGenerator.java
@@ -231,6 +231,7 @@ public class CodeJavaGenerator {
      * @return a java code which casts obj to a type
      */
     public static String castToType(String typeName, String objCode){
+        if (typeName == null) return objCode;
         return String.format("((%s)(%s))", handleNestedSymbolInTypeName(typeName), objCode);
     }
 

--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/problem/rpc/RPCEndpointsBuilder.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/problem/rpc/RPCEndpointsBuilder.java
@@ -434,7 +434,7 @@ public class RPCEndpointsBuilder {
                 StringType stringType = new StringType();
                 namedValue = new StringParam(name, stringType, accessibleSchema);
             } else if (clazz.isEnum()) {
-                String [] items = Arrays.stream(clazz.getEnumConstants()).map(Object::toString).toArray(String[]::new);
+                String [] items = Arrays.stream(clazz.getEnumConstants()).map(e-> getNameEnumConstant(e)).toArray(String[]::new);
                 EnumType enumType = new EnumType(clazz.getSimpleName(), clazz.getName(), items, clazz);
                 EnumParam param = new EnumParam(name, enumType, accessibleSchema);
                 //register this type in the schema
@@ -592,6 +592,16 @@ public class RPCEndpointsBuilder {
         }
 
         return namedValue;
+    }
+
+    private static String getNameEnumConstant(Object object) {
+        try {
+            Method name = object.getClass().getMethod("name");
+            name.setAccessible(true);
+            return (String) name.invoke(object);
+        } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+            return object.toString();
+        }
     }
 
     private static void handleGenericSuperclass(Class clazz, Map<TypeVariable, Type> map){

--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/problem/rpc/RPCEndpointsBuilder.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/problem/rpc/RPCEndpointsBuilder.java
@@ -600,6 +600,7 @@ public class RPCEndpointsBuilder {
             name.setAccessible(true);
             return (String) name.invoke(object);
         } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+            SimpleLogger.warn("Driver Error: fail to extract name for enum constant", e);
             return object.toString();
         }
     }

--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/problem/rpc/schema/params/ByteParam.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/problem/rpc/schema/params/ByteParam.java
@@ -72,4 +72,9 @@ public class ByteParam extends PrimitiveOrWrapperParam<Byte> {
             return responseVarName+".byteValue()";
         return responseVarName;
     }
+
+    @Override
+    public String getCastType() {
+        return byte.class.getName();
+    }
 }

--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/problem/rpc/schema/params/ObjectParam.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/problem/rpc/schema/params/ObjectParam.java
@@ -34,7 +34,7 @@ public class ObjectParam extends NamedTypedValue<ObjectType, List<NamedTypedValu
             Object instance = clazz.newInstance();
             for (NamedTypedValue v: getValue()){
                 if (v.accessibleSchema == null || v.accessibleSchema.isAccessible){
-                    Field f = clazz.getDeclaredField(v.getName());
+                    Field f = clazz.getField(v.getName());
                     f.setAccessible(true);
                     Object vins = v.newInstance();
                     if (vins != null)
@@ -125,7 +125,7 @@ public class ObjectParam extends NamedTypedValue<ObjectType, List<NamedTypedValu
             NamedTypedValue copy = f.copyStructureWithProperties();
             try {
                 if (f.accessibleSchema == null || f.accessibleSchema.isAccessible){
-                    Field fi = clazz.getDeclaredField(f.getName());
+                    Field fi = clazz.getField(f.getName());
                     fi.setAccessible(true);
                     Object fiv = fi.get(instance);
                     copy.setValueBasedOnInstance(fiv);

--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/problem/rpc/schema/params/PrimitiveOrWrapperParam.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/problem/rpc/schema/params/PrimitiveOrWrapperParam.java
@@ -138,7 +138,7 @@ public abstract class PrimitiveOrWrapperParam<V> extends NamedTypedValue<Primiti
         } else{
             if (accessibleSchema.setterMethodName == null)
                 throw new IllegalStateException("Error: private field, but there is no setter method");
-            code = CodeJavaGenerator.oneLineSetterInstance(accessibleSchema.setterMethodName, null, variableName, getValueAsJavaString());
+            code = CodeJavaGenerator.oneLineSetterInstance(accessibleSchema.setterMethodName, getCastType(), variableName, getValueAsJavaString());
         }
         return Collections.singletonList(CodeJavaGenerator.getIndent(indent)+ code);
     }
@@ -177,5 +177,13 @@ public abstract class PrimitiveOrWrapperParam<V> extends NamedTypedValue<Primiti
             ((PrimitiveOrWrapperParam)copy).setMin(min);
             ((PrimitiveOrWrapperParam)copy).setMax(max);
         }
+    }
+
+    /**
+     *
+     * @return a cast type for this param, null means that there is no need to cast the value to a type
+     */
+    public String getCastType() {
+        return null;
     }
 }

--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/problem/rpc/schema/params/PrimitiveOrWrapperParam.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/problem/rpc/schema/params/PrimitiveOrWrapperParam.java
@@ -138,7 +138,7 @@ public abstract class PrimitiveOrWrapperParam<V> extends NamedTypedValue<Primiti
         } else{
             if (accessibleSchema.setterMethodName == null)
                 throw new IllegalStateException("Error: private field, but there is no setter method");
-            code = CodeJavaGenerator.oneLineSetterInstance(accessibleSchema.setterMethodName, getType().getFullTypeName(), variableName, getValueAsJavaString());
+            code = CodeJavaGenerator.oneLineSetterInstance(accessibleSchema.setterMethodName, null, variableName, getValueAsJavaString());
         }
         return Collections.singletonList(CodeJavaGenerator.getIndent(indent)+ code);
     }

--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/problem/rpc/schema/params/ShortParam.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/problem/rpc/schema/params/ShortParam.java
@@ -69,4 +69,9 @@ public class ShortParam extends PrimitiveOrWrapperParam<Short> {
             return responseVarName+".shortValue()";
         return responseVarName;
     }
+
+    @Override
+    public String getCastType() {
+        return short.class.getName();
+    }
 }

--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/problem/rpc/schema/params/StringParam.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/problem/rpc/schema/params/StringParam.java
@@ -143,7 +143,7 @@ public class StringParam extends NamedTypedValue<StringType, String> {
         else{
             if (accessibleSchema.setterMethodName == null)
                 throw new IllegalStateException("Error: private field, but there is no setter method");
-            code = CodeJavaGenerator.oneLineSetterInstance(accessibleSchema.setterMethodName, getType().getFullTypeName(), variableName, getValueAsJavaString());
+            code = CodeJavaGenerator.oneLineSetterInstance(accessibleSchema.setterMethodName, null, variableName, getValueAsJavaString());
         }
         return Collections.singletonList(CodeJavaGenerator.getIndent(indent)+ code);
     }

--- a/client-java/controller/src/test/java/com/thrift/example/artificial/EnumWithConstructor.java
+++ b/client-java/controller/src/test/java/com/thrift/example/artificial/EnumWithConstructor.java
@@ -1,0 +1,36 @@
+package com.thrift.example.artificial;
+
+import java.util.Arrays;
+import java.util.List;
+
+public enum EnumWithConstructor {
+
+    FIRST(1, "first", Arrays.asList(EnumKind.ONE)),
+    SECOND(2, "second", Arrays.asList(EnumKind.ONE, EnumKind.TWO)),
+    THIRD(3, "third", Arrays.asList(EnumKind.ONE, EnumKind.TWO, EnumKind.THREE));
+
+    private int code;
+
+    private String desc;
+
+    private List<EnumKind> kindList;
+
+
+    EnumWithConstructor(int code, String desc, List<EnumKind> kindList) {
+        this.code = code;
+        this.desc = desc;
+        this.kindList = kindList;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getDesc() {
+        return desc;
+    }
+
+    public List<EnumKind> getKindList() {
+        return kindList;
+    }
+}

--- a/client-java/controller/src/test/java/com/thrift/example/artificial/EnumWithConstructor.java
+++ b/client-java/controller/src/test/java/com/thrift/example/artificial/EnumWithConstructor.java
@@ -33,4 +33,13 @@ public enum EnumWithConstructor {
     public List<EnumKind> getKindList() {
         return kindList;
     }
+
+    @Override
+    public String toString() {
+        return "EnumWithConstructor{" +
+                "code=" + code +
+                ", desc='" + desc + '\'' +
+                ", kindList=" + kindList +
+                '}';
+    }
 }

--- a/client-java/controller/src/test/java/com/thrift/example/artificial/ObjectEnum.java
+++ b/client-java/controller/src/test/java/com/thrift/example/artificial/ObjectEnum.java
@@ -1,0 +1,6 @@
+package com.thrift.example.artificial;
+
+public class ObjectEnum {
+
+    public EnumWithConstructor enumWithConstructor;
+}

--- a/client-java/controller/src/test/java/com/thrift/example/artificial/PrivateFieldInRequestDto.java
+++ b/client-java/controller/src/test/java/com/thrift/example/artificial/PrivateFieldInRequestDto.java
@@ -64,4 +64,65 @@ public class PrivateFieldInRequestDto {
     public void setPribool(boolean pribool) {
         this.pribool = pribool;
     }
+
+    public Byte getPriBByte() {
+        return priBByte;
+    }
+
+    public void setPriBByte(Byte priBByte) {
+        this.priBByte = priBByte;
+    }
+
+    private Byte priBByte;
+
+
+    private byte pribyte;
+
+    public byte getPribyte() {
+        return pribyte;
+    }
+
+    public void setPribyte(byte pribyte) {
+        this.pribyte = pribyte;
+    }
+
+    private Character priCharacter;
+
+    private char priChar;
+
+    public Character getPriCharacter() {
+        return priCharacter;
+    }
+
+    public void setPriCharacter(Character priCharacter) {
+        this.priCharacter = priCharacter;
+    }
+
+    public char getPriChar() {
+        return priChar;
+    }
+
+    public void setPriChar(char priChar) {
+        this.priChar = priChar;
+    }
+
+    private short priShort;
+
+    public short getPriShort() {
+        return priShort;
+    }
+
+    public void setPriShort(short priShort) {
+        this.priShort = priShort;
+    }
+
+    private Short priSShort;
+
+    public Short getPriSShort() {
+        return priSShort;
+    }
+
+    public void setPriSShort(Short priSShort) {
+        this.priSShort = priSShort;
+    }
 }

--- a/client-java/controller/src/test/java/com/thrift/example/artificial/RPCInterfaceExample.java
+++ b/client-java/controller/src/test/java/com/thrift/example/artificial/RPCInterfaceExample.java
@@ -64,4 +64,6 @@ public interface RPCInterfaceExample {
     NestedGenericDto<String> handleNestedGenericString(NestedGenericDto<String> dto);
 
     void handleException(String type) throws Exception;
+
+    String handleEnumWithConstructor(ObjectEnum arg1);
 }

--- a/client-java/controller/src/test/java/com/thrift/example/artificial/RPCInterfaceExampleImpl.java
+++ b/client-java/controller/src/test/java/com/thrift/example/artificial/RPCInterfaceExampleImpl.java
@@ -217,4 +217,10 @@ public class RPCInterfaceExampleImpl implements RPCInterfaceExample{
             throw new IllegalArgumentException(type);
         throw new RuntimeException(type);
     }
+
+    @Override
+    public String handleEnumWithConstructor(ObjectEnum arg1) {
+        if (arg1 == null || arg1.enumWithConstructor == null) return null;
+        return arg1.enumWithConstructor.getDesc();
+    }
 }

--- a/client-java/controller/src/test/java/org/evomaster/client/java/controller/problem/rpc/ExampleBuilderTest.java
+++ b/client-java/controller/src/test/java/org/evomaster/client/java/controller/problem/rpc/ExampleBuilderTest.java
@@ -431,7 +431,7 @@ public class ExampleBuilderTest extends RPCEndpointsBuilderTestBase {
         assertEquals("{", javaCodes.get(1));
         assertEquals(" arg0 = new com.thrift.example.artificial.PrivateFieldInRequestDto();", javaCodes.get(2));
         assertEquals(" arg0.pubField = \"foo\";", javaCodes.get(3));
-        assertEquals(" arg0.setPriField(((java.lang.String)(\"bar\")));", javaCodes.get(4));
+        assertEquals(" arg0.setPriField(\"bar\");", javaCodes.get(4));
         assertEquals(" java.util.List<java.lang.String> arg0_stringList = null;", javaCodes.get(5));
         assertEquals(" {", javaCodes.get(6));
         assertEquals("  arg0_stringList = new java.util.ArrayList<>();", javaCodes.get(7));
@@ -444,8 +444,8 @@ public class ExampleBuilderTest extends RPCEndpointsBuilderTestBase {
         assertEquals(" }", javaCodes.get(14));
         assertEquals(" arg0.setStringList(arg0_stringList);", javaCodes.get(15));
         assertEquals(" arg0.setPriEnum(((com.thrift.example.artificial.EnumKind)(com.thrift.example.artificial.EnumKind.ONE)));", javaCodes.get(16));
-        assertEquals(" arg0.setPriBoolean(((java.lang.Boolean)(true)));", javaCodes.get(17));
-        assertEquals(" arg0.setPribool(((boolean)(false)));", javaCodes.get(18));
+        assertEquals(" arg0.setPriBoolean(true);", javaCodes.get(17));
+        assertEquals(" arg0.setPribool(false);", javaCodes.get(18));
         assertEquals("}", javaCodes.get(19));
 
 
@@ -478,7 +478,7 @@ public class ExampleBuilderTest extends RPCEndpointsBuilderTestBase {
         assertEquals(" {", javaCodesForResponse.get(5));
         assertEquals("  tmp_priRequest = new com.thrift.example.artificial.PrivateFieldInRequestDto();", javaCodesForResponse.get(6));
         assertEquals("  tmp_priRequest.pubField = \"foo\";", javaCodesForResponse.get(7));
-        assertEquals("  tmp_priRequest.setPriField(((java.lang.String)(\"bar\")));", javaCodesForResponse.get(8));
+        assertEquals("  tmp_priRequest.setPriField(\"bar\");", javaCodesForResponse.get(8));
         assertEquals("  java.util.List<java.lang.String> tmp_priRequest_stringList = null;", javaCodesForResponse.get(9));
         assertEquals("  {", javaCodesForResponse.get(10));
         assertEquals("   tmp_priRequest_stringList = new java.util.ArrayList<>();", javaCodesForResponse.get(11));
@@ -491,8 +491,8 @@ public class ExampleBuilderTest extends RPCEndpointsBuilderTestBase {
         assertEquals("  }", javaCodesForResponse.get(18));
         assertEquals("  tmp_priRequest.setStringList(tmp_priRequest_stringList);", javaCodesForResponse.get(19));
         assertEquals("  tmp_priRequest.setPriEnum(((com.thrift.example.artificial.EnumKind)(com.thrift.example.artificial.EnumKind.ONE)));", javaCodesForResponse.get(20));
-        assertEquals("  tmp_priRequest.setPriBoolean(((java.lang.Boolean)(true)));", javaCodesForResponse.get(21));
-        assertEquals("  tmp_priRequest.setPribool(((boolean)(false)));", javaCodesForResponse.get(22));
+        assertEquals("  tmp_priRequest.setPriBoolean(true);", javaCodesForResponse.get(21));
+        assertEquals("  tmp_priRequest.setPribool(false);", javaCodesForResponse.get(22));
         assertEquals(" }", javaCodesForResponse.get(23));
         assertEquals(" tmp.setPriRequest(tmp_priRequest);", javaCodesForResponse.get(24));
         assertEquals("}", javaCodesForResponse.get(25));
@@ -539,7 +539,7 @@ public class ExampleBuilderTest extends RPCEndpointsBuilderTestBase {
         assertEquals(" arg0.setStringList(arg0_stringList);", javaCodes.get(6));
         assertEquals(" arg0.setPriEnum(null);", javaCodes.get(7));
         assertEquals(" arg0.setPriBoolean(null);", javaCodes.get(8));
-        assertEquals(" arg0.setPribool(((boolean)(false)));", javaCodes.get(9));
+        assertEquals(" arg0.setPribool(false);", javaCodes.get(9));
         assertEquals("}", javaCodes.get(10));
 
 
@@ -595,7 +595,7 @@ public class ExampleBuilderTest extends RPCEndpointsBuilderTestBase {
         assertEquals("  tmp_priRequest.setStringList(tmp_priRequest_stringList);", javaCodesForResponse.get(10));
         assertEquals("  tmp_priRequest.setPriEnum(null);", javaCodesForResponse.get(11));
         assertEquals("  tmp_priRequest.setPriBoolean(null);", javaCodesForResponse.get(12));
-        assertEquals("  tmp_priRequest.setPribool(((boolean)(false)));", javaCodesForResponse.get(13));
+        assertEquals("  tmp_priRequest.setPribool(false);", javaCodesForResponse.get(13));
         assertEquals(" }", javaCodesForResponse.get(14));
         assertEquals(" tmp.setPriRequest(tmp_priRequest);", javaCodesForResponse.get(15));
         assertEquals("}", javaCodesForResponse.get(16));

--- a/client-java/controller/src/test/java/org/evomaster/client/java/controller/problem/rpc/ExampleBuilderTest.java
+++ b/client-java/controller/src/test/java/org/evomaster/client/java/controller/problem/rpc/ExampleBuilderTest.java
@@ -137,7 +137,12 @@ public class ExampleBuilderTest extends RPCEndpointsBuilderTestBase {
         p1.setValueBasedOnInstance(objectEnum);
         List<String> testScript = p1.newInstanceWithJava(0);
 
-        testScript.forEach(System.out::println);
+        assertEquals(5, testScript.size());
+        assertEquals("com.thrift.example.artificial.ObjectEnum arg0 = null;", testScript.get(0));
+        assertEquals("{", testScript.get(1));
+        assertEquals(" arg0 = new com.thrift.example.artificial.ObjectEnum();", testScript.get(2));
+        assertEquals(" arg0.enumWithConstructor = com.thrift.example.artificial.EnumWithConstructor.FIRST;", testScript.get(3));
+        assertEquals("}", testScript.get(4));
     }
 
     @Test

--- a/client-java/controller/src/test/java/org/evomaster/client/java/controller/problem/rpc/ExampleBuilderTest.java
+++ b/client-java/controller/src/test/java/org/evomaster/client/java/controller/problem/rpc/ExampleBuilderTest.java
@@ -386,7 +386,7 @@ public class ExampleBuilderTest extends RPCEndpointsBuilderTestBase {
         assertTrue(p1.getType() instanceof ObjectType);
 
         List<NamedTypedValue> fs = ((ObjectType) p1.getType()).getFields();
-        assertEquals(6, fs.size());
+        assertEquals(12, fs.size());
 
         for (NamedTypedValue f: fs){
             if (f.getName().equals("pubField")){
@@ -411,6 +411,30 @@ public class ExampleBuilderTest extends RPCEndpointsBuilderTestBase {
                 assertFalse(f.accessibleSchema.isAccessible);
                 assertEquals("setPribool", f.accessibleSchema.setterMethodName);
                 assertEquals("isPribool", f.accessibleSchema.getterMethodName);
+            } else if (f.getName().equals("pribyte")){
+                assertFalse(f.accessibleSchema.isAccessible);
+                assertEquals("setPribyte", f.accessibleSchema.setterMethodName);
+                assertEquals("getPribyte", f.accessibleSchema.getterMethodName);
+            } else if (f.getName().equals("priBByte")){
+                assertFalse(f.accessibleSchema.isAccessible);
+                assertEquals("setPriBByte", f.accessibleSchema.setterMethodName);
+                assertEquals("getPriBByte", f.accessibleSchema.getterMethodName);
+            } else if (f.getName().equals("priCharacter")){
+                assertFalse(f.accessibleSchema.isAccessible);
+                assertEquals("setPriCharacter", f.accessibleSchema.setterMethodName);
+                assertEquals("getPriCharacter", f.accessibleSchema.getterMethodName);
+            } else if (f.getName().equals("priChar")){
+                assertFalse(f.accessibleSchema.isAccessible);
+                assertEquals("setPriChar", f.accessibleSchema.setterMethodName);
+                assertEquals("getPriChar", f.accessibleSchema.getterMethodName);
+            } else if (f.getName().equals("priSShort")){
+                assertFalse(f.accessibleSchema.isAccessible);
+                assertEquals("setPriSShort", f.accessibleSchema.setterMethodName);
+                assertEquals("getPriSShort", f.accessibleSchema.getterMethodName);
+            } else if (f.getName().equals("priShot")){
+                assertFalse(f.accessibleSchema.isAccessible);
+                assertEquals("setPriShot", f.accessibleSchema.setterMethodName);
+                assertEquals("getPriShot", f.accessibleSchema.getterMethodName);
             }
         }
 
@@ -420,13 +444,19 @@ public class ExampleBuilderTest extends RPCEndpointsBuilderTestBase {
             setStringList(Arrays.asList("1","2","3"));
             setPriEnum(EnumKind.ONE);
             setPriBoolean(true);
+            setPriBByte((byte) 15);
+            setPribyte((byte) 5);
+            setPriChar('0');
+            setPriCharacter('a');
+            setPriShort((short) 2);
+            setPriSShort((short) 42);
         }};
 
         p1.setValueBasedOnInstance(p1Instance);
 
         List<String> javaCodes = p1.newInstanceWithJava(0);
 
-        assertEquals(20, javaCodes.size());
+        assertEquals(26, javaCodes.size());
         assertEquals("com.thrift.example.artificial.PrivateFieldInRequestDto arg0 = null;", javaCodes.get(0));
         assertEquals("{", javaCodes.get(1));
         assertEquals(" arg0 = new com.thrift.example.artificial.PrivateFieldInRequestDto();", javaCodes.get(2));
@@ -446,11 +476,18 @@ public class ExampleBuilderTest extends RPCEndpointsBuilderTestBase {
         assertEquals(" arg0.setPriEnum(((com.thrift.example.artificial.EnumKind)(com.thrift.example.artificial.EnumKind.ONE)));", javaCodes.get(16));
         assertEquals(" arg0.setPriBoolean(true);", javaCodes.get(17));
         assertEquals(" arg0.setPribool(false);", javaCodes.get(18));
-        assertEquals("}", javaCodes.get(19));
+        assertEquals(" arg0.setPriBByte(((byte)(15)));", javaCodes.get(19));
+        assertEquals(" arg0.setPribyte(((byte)(5)));", javaCodes.get(20));
+        assertEquals(" arg0.setPriCharacter('a');", javaCodes.get(21));
+        assertEquals(" arg0.setPriChar('0');", javaCodes.get(22));
+        assertEquals(" arg0.setPriShort(((short)(2)));", javaCodes.get(23));
+        assertEquals(" arg0.setPriSShort(((short)(42)));", javaCodes.get(24));
+        assertEquals("}", javaCodes.get(25));
 
 
         List<String> assertionJavaCode = p1.newAssertionWithJava(0, "res1", -1);
-        assertEquals(9, assertionJavaCode.size());
+
+        assertEquals(15, assertionJavaCode.size());
         assertEquals("assertEquals(\"foo\", res1.pubField);", assertionJavaCode.get(0));
         assertEquals("assertEquals(\"bar\", res1.getPriField());", assertionJavaCode.get(1));
         assertEquals("assertEquals(3, res1.getStringList().size());", assertionJavaCode.get(2));
@@ -460,6 +497,12 @@ public class ExampleBuilderTest extends RPCEndpointsBuilderTestBase {
         assertEquals("assertEquals(com.thrift.example.artificial.EnumKind.ONE, res1.getPriEnum());", assertionJavaCode.get(6));
         assertEquals("assertEquals(true, res1.getPriBoolean().booleanValue());", assertionJavaCode.get(7));
         assertEquals("assertEquals(false, res1.isPribool());", assertionJavaCode.get(8));
+        assertEquals("assertEquals(15, res1.getPriBByte().byteValue());", assertionJavaCode.get(9));
+        assertEquals("assertEquals(5, res1.getPribyte());", assertionJavaCode.get(10));
+        assertEquals("assertEquals('a', res1.getPriCharacter().charValue());", assertionJavaCode.get(11));
+        assertEquals("assertEquals('0', res1.getPriChar());", assertionJavaCode.get(12));
+        assertEquals("assertEquals(2, res1.getPriShort());", assertionJavaCode.get(13));
+        assertEquals("assertEquals(42, res1.getPriSShort().shortValue());", assertionJavaCode.get(14));
 
         NamedTypedValue res = endpoint.getResponse();
         PrivateFieldInResponseDto resInstance = new PrivateFieldInResponseDto(){{
@@ -469,7 +512,7 @@ public class ExampleBuilderTest extends RPCEndpointsBuilderTestBase {
 
         res.setValueBasedOnInstance(resInstance);
         List<String> javaCodesForResponse = res.newInstanceWithJava(true, true, "tmp", 0);
-        assertEquals(26, javaCodesForResponse.size());
+        assertEquals(32, javaCodesForResponse.size());
         assertEquals("com.thrift.example.artificial.PrivateFieldInResponseDto tmp = null;", javaCodesForResponse.get(0));
         assertEquals("{", javaCodesForResponse.get(1));
         assertEquals(" tmp = new com.thrift.example.artificial.PrivateFieldInResponseDto();", javaCodesForResponse.get(2));
@@ -493,12 +536,18 @@ public class ExampleBuilderTest extends RPCEndpointsBuilderTestBase {
         assertEquals("  tmp_priRequest.setPriEnum(((com.thrift.example.artificial.EnumKind)(com.thrift.example.artificial.EnumKind.ONE)));", javaCodesForResponse.get(20));
         assertEquals("  tmp_priRequest.setPriBoolean(true);", javaCodesForResponse.get(21));
         assertEquals("  tmp_priRequest.setPribool(false);", javaCodesForResponse.get(22));
-        assertEquals(" }", javaCodesForResponse.get(23));
-        assertEquals(" tmp.setPriRequest(tmp_priRequest);", javaCodesForResponse.get(24));
-        assertEquals("}", javaCodesForResponse.get(25));
+        assertEquals("  tmp_priRequest.setPriBByte(((byte)(15)));", javaCodesForResponse.get(23));
+        assertEquals("  tmp_priRequest.setPribyte(((byte)(5)));", javaCodesForResponse.get(24));
+        assertEquals("  tmp_priRequest.setPriCharacter('a');", javaCodesForResponse.get(25));
+        assertEquals("  tmp_priRequest.setPriChar('0');", javaCodesForResponse.get(26));
+        assertEquals("  tmp_priRequest.setPriShort(((short)(2)));", javaCodesForResponse.get(27));
+        assertEquals("  tmp_priRequest.setPriSShort(((short)(42)));", javaCodesForResponse.get(28));
+        assertEquals(" }", javaCodesForResponse.get(29));
+        assertEquals(" tmp.setPriRequest(tmp_priRequest);", javaCodesForResponse.get(30));
+        assertEquals("}", javaCodesForResponse.get(31));
 
         List<String> assertionJavaCodeForResponse = res.newAssertionWithJava(0, "res1", -1);
-        assertEquals(10, assertionJavaCodeForResponse.size());
+        assertEquals(16, assertionJavaCodeForResponse.size());
         assertEquals("assertEquals(42, res1.pubField);", assertionJavaCodeForResponse.get(0));
         assertEquals("assertEquals(\"foo\", res1.getPriRequest().pubField);", assertionJavaCodeForResponse.get(1));
         assertEquals("assertEquals(\"bar\", res1.getPriRequest().getPriField());", assertionJavaCodeForResponse.get(2));
@@ -509,6 +558,12 @@ public class ExampleBuilderTest extends RPCEndpointsBuilderTestBase {
         assertEquals("assertEquals(com.thrift.example.artificial.EnumKind.ONE, res1.getPriRequest().getPriEnum());", assertionJavaCodeForResponse.get(7));
         assertEquals("assertEquals(true, res1.getPriRequest().getPriBoolean().booleanValue());", assertionJavaCodeForResponse.get(8));
         assertEquals("assertEquals(false, res1.getPriRequest().isPribool());", assertionJavaCodeForResponse.get(9));
+        assertEquals("assertEquals(15, res1.getPriRequest().getPriBByte().byteValue());", assertionJavaCodeForResponse.get(10));
+        assertEquals("assertEquals(5, res1.getPriRequest().getPribyte());", assertionJavaCodeForResponse.get(11));
+        assertEquals("assertEquals('a', res1.getPriRequest().getPriCharacter().charValue());", assertionJavaCodeForResponse.get(12));
+        assertEquals("assertEquals('0', res1.getPriRequest().getPriChar());", assertionJavaCodeForResponse.get(13));
+        assertEquals("assertEquals(2, res1.getPriRequest().getPriShort());", assertionJavaCodeForResponse.get(14));
+        assertEquals("assertEquals(42, res1.getPriRequest().getPriSShort().shortValue());", assertionJavaCodeForResponse.get(15));
     }
 
 
@@ -529,7 +584,7 @@ public class ExampleBuilderTest extends RPCEndpointsBuilderTestBase {
 
         List<String> javaCodes = p1.newInstanceWithJava(0);
 
-        assertEquals(11, javaCodes.size());
+        assertEquals(17, javaCodes.size());
         assertEquals("com.thrift.example.artificial.PrivateFieldInRequestDto arg0 = null;", javaCodes.get(0));
         assertEquals("{", javaCodes.get(1));
         assertEquals(" arg0 = new com.thrift.example.artificial.PrivateFieldInRequestDto();", javaCodes.get(2));
@@ -540,17 +595,29 @@ public class ExampleBuilderTest extends RPCEndpointsBuilderTestBase {
         assertEquals(" arg0.setPriEnum(null);", javaCodes.get(7));
         assertEquals(" arg0.setPriBoolean(null);", javaCodes.get(8));
         assertEquals(" arg0.setPribool(false);", javaCodes.get(9));
-        assertEquals("}", javaCodes.get(10));
+        assertEquals(" arg0.setPriBByte(null);", javaCodes.get(10));
+        assertEquals(" arg0.setPribyte(((byte)(0)));", javaCodes.get(11));
+        assertEquals(" arg0.setPriCharacter(null);", javaCodes.get(12));
+        assertEquals(" arg0.setPriChar('"+'\u0000'+"');", javaCodes.get(13));
+        assertEquals(" arg0.setPriShort(((short)(0)));", javaCodes.get(14));
+        assertEquals(" arg0.setPriSShort(null);", javaCodes.get(15));
+        assertEquals("}", javaCodes.get(16));
 
 
         List<String> assertionJavaCode = p1.newAssertionWithJava(0, "res1", -1);
-        assertEquals(6, assertionJavaCode.size());
+        assertEquals(12, assertionJavaCode.size());
         assertEquals("assertNull(res1.pubField);", assertionJavaCode.get(0));
         assertEquals("assertNull(res1.getPriField());", assertionJavaCode.get(1));
         assertEquals("assertNull(res1.getStringList());", assertionJavaCode.get(2));
         assertEquals("assertNull(res1.getPriEnum());", assertionJavaCode.get(3));
         assertEquals("assertNull(res1.getPriBoolean());", assertionJavaCode.get(4));
         assertEquals("assertEquals(false, res1.isPribool());", assertionJavaCode.get(5));
+        assertEquals("assertNull(res1.getPriBByte());", assertionJavaCode.get(6));
+        assertEquals("assertEquals(0, res1.getPribyte());", assertionJavaCode.get(7));
+        assertEquals("assertNull(res1.getPriCharacter());", assertionJavaCode.get(8));
+        assertEquals("assertEquals('"+'\u0000'+"', res1.getPriChar());", assertionJavaCode.get(9));
+        assertEquals("assertEquals(0, res1.getPriShort());", assertionJavaCode.get(10));
+        assertEquals("assertNull(res1.getPriSShort());", assertionJavaCode.get(11));
 
         NamedTypedValue res = endpoint.getResponse();
         PrivateFieldInResponseDto resInstance = new PrivateFieldInResponseDto(){{
@@ -581,7 +648,7 @@ public class ExampleBuilderTest extends RPCEndpointsBuilderTestBase {
         res.setValueBasedOnInstance(resInstance2);
 
         javaCodesForResponse = res.newInstanceWithJava(true, true, "tmp", 0);
-        assertEquals(17, javaCodesForResponse.size());
+        assertEquals(23, javaCodesForResponse.size());
         assertEquals("com.thrift.example.artificial.PrivateFieldInResponseDto tmp = null;", javaCodesForResponse.get(0));
         assertEquals("{", javaCodesForResponse.get(1));
         assertEquals(" tmp = new com.thrift.example.artificial.PrivateFieldInResponseDto();", javaCodesForResponse.get(2));
@@ -596,12 +663,18 @@ public class ExampleBuilderTest extends RPCEndpointsBuilderTestBase {
         assertEquals("  tmp_priRequest.setPriEnum(null);", javaCodesForResponse.get(11));
         assertEquals("  tmp_priRequest.setPriBoolean(null);", javaCodesForResponse.get(12));
         assertEquals("  tmp_priRequest.setPribool(false);", javaCodesForResponse.get(13));
-        assertEquals(" }", javaCodesForResponse.get(14));
-        assertEquals(" tmp.setPriRequest(tmp_priRequest);", javaCodesForResponse.get(15));
-        assertEquals("}", javaCodesForResponse.get(16));
+        assertEquals("  tmp_priRequest.setPriBByte(null);", javaCodesForResponse.get(14));
+        assertEquals("  tmp_priRequest.setPribyte(((byte)(0)));", javaCodesForResponse.get(15));
+        assertEquals("  tmp_priRequest.setPriCharacter(null);", javaCodesForResponse.get(16));
+        assertEquals("  tmp_priRequest.setPriChar('"+'\u0000'+"');", javaCodesForResponse.get(17));
+        assertEquals("  tmp_priRequest.setPriShort(((short)(0)));", javaCodesForResponse.get(18));
+        assertEquals("  tmp_priRequest.setPriSShort(null);", javaCodesForResponse.get(19));
+        assertEquals(" }", javaCodesForResponse.get(20));
+        assertEquals(" tmp.setPriRequest(tmp_priRequest);", javaCodesForResponse.get(21));
+        assertEquals("}", javaCodesForResponse.get(22));
 
         assertionJavaCodeForResponse = res.newAssertionWithJava(0, "res1", -1);
-        assertEquals(7, assertionJavaCodeForResponse.size());
+        assertEquals(13, assertionJavaCodeForResponse.size());
         assertEquals("assertEquals(42, res1.pubField);", assertionJavaCodeForResponse.get(0));
         assertEquals("assertNull(res1.getPriRequest().pubField);", assertionJavaCodeForResponse.get(1));
         assertEquals("assertNull(res1.getPriRequest().getPriField());", assertionJavaCodeForResponse.get(2));
@@ -609,6 +682,12 @@ public class ExampleBuilderTest extends RPCEndpointsBuilderTestBase {
         assertEquals("assertNull(res1.getPriRequest().getPriEnum());", assertionJavaCodeForResponse.get(4));
         assertEquals("assertNull(res1.getPriRequest().getPriBoolean());", assertionJavaCodeForResponse.get(5));
         assertEquals("assertEquals(false, res1.getPriRequest().isPribool());", assertionJavaCodeForResponse.get(6));
+        assertEquals("assertNull(res1.getPriRequest().getPriBByte());", assertionJavaCodeForResponse.get(7));
+        assertEquals("assertEquals(0, res1.getPriRequest().getPribyte());", assertionJavaCodeForResponse.get(8));
+        assertEquals("assertNull(res1.getPriRequest().getPriCharacter());", assertionJavaCodeForResponse.get(9));
+        assertEquals("assertEquals('"+'\u0000'+"', res1.getPriRequest().getPriChar());", assertionJavaCodeForResponse.get(10));
+        assertEquals("assertEquals(0, res1.getPriRequest().getPriShort());", assertionJavaCodeForResponse.get(11));
+        assertEquals("assertNull(res1.getPriRequest().getPriSShort());", assertionJavaCodeForResponse.get(12));
     }
 
     @Test

--- a/client-java/controller/src/test/java/org/evomaster/client/java/controller/problem/rpc/ExampleBuilderTest.java
+++ b/client-java/controller/src/test/java/org/evomaster/client/java/controller/problem/rpc/ExampleBuilderTest.java
@@ -34,7 +34,7 @@ public class ExampleBuilderTest extends RPCEndpointsBuilderTestBase {
 
     @Override
     public int expectedNumberOfEndpoints() {
-        return 27;
+        return 28;
     }
 
     @Override
@@ -117,6 +117,27 @@ public class ExampleBuilderTest extends RPCEndpointsBuilderTestBase {
                     }};
                 }}
         );
+    }
+
+
+    @Test
+    public void testEnumWithConstructor(){
+        EndpointSchema endpoint = getOneEndpoint("handleEnumWithConstructor");
+        assertNotNull(endpoint.getResponse());
+        assertNotNull(endpoint.getRequestParams());
+        assertEquals(1, endpoint.getRequestParams().size());
+
+        NamedTypedValue p1 = endpoint.getRequestParams().get(0);
+        assertTrue(p1 instanceof ObjectParam);
+
+        ObjectEnum objectEnum = new ObjectEnum(){{
+            enumWithConstructor = EnumWithConstructor.FIRST;
+        }};
+
+        p1.setValueBasedOnInstance(objectEnum);
+        List<String> testScript = p1.newInstanceWithJava(0);
+
+        testScript.forEach(System.out::println);
     }
 
     @Test

--- a/client-java/controller/src/test/java/org/evomaster/client/java/controller/problem/rpc/invocation/RPCSutControllerTest.java
+++ b/client-java/controller/src/test/java/org/evomaster/client/java/controller/problem/rpc/invocation/RPCSutControllerTest.java
@@ -346,8 +346,8 @@ public class RPCSutControllerTest {
         assertEquals(" com.thrift.example.artificial.StringChildDto arg0 = null;", responseDto.testScript.get(2));
         assertEquals(" {", responseDto.testScript.get(3));
         assertEquals("  arg0 = new com.thrift.example.artificial.StringChildDto();", responseDto.testScript.get(4));
-        assertEquals("  arg0.setCode(((java.lang.String)(\"ppcode\")));", responseDto.testScript.get(5));
-        assertEquals("  arg0.setMessage(((java.lang.String)(\"pmsg\")));", responseDto.testScript.get(6));
+        assertEquals("  arg0.setCode(\"ppcode\");", responseDto.testScript.get(5));
+        assertEquals("  arg0.setMessage(\"pmsg\");", responseDto.testScript.get(6));
         assertEquals(" }", responseDto.testScript.get(7));
         assertEquals(" res1 = ((com.thrift.example.artificial.RPCInterfaceExampleImpl)(controller.getRPCClient(\"com.thrift.example.artificial.RPCInterfaceExample\"))).handledInheritedGenericStringDto(arg0);", responseDto.testScript.get(8));
         assertEquals("}", responseDto.testScript.get(9));
@@ -402,8 +402,8 @@ public class RPCSutControllerTest {
         assertEquals(" com.thrift.example.artificial.IntChildDto arg0 = null;", responseDto.testScript.get(2));
         assertEquals(" {", responseDto.testScript.get(3));
         assertEquals("  arg0 = new com.thrift.example.artificial.IntChildDto();", responseDto.testScript.get(4));
-        assertEquals("  arg0.setCode(((java.lang.Integer)(1)));", responseDto.testScript.get(5));
-        assertEquals("  arg0.setMessage(((java.lang.Integer)(2)));", responseDto.testScript.get(6));
+        assertEquals("  arg0.setCode(1);", responseDto.testScript.get(5));
+        assertEquals("  arg0.setMessage(2);", responseDto.testScript.get(6));
         assertEquals(" }", responseDto.testScript.get(7));
         assertEquals(" res1 = ((com.thrift.example.artificial.RPCInterfaceExampleImpl)(controller.getRPCClient(\"com.thrift.example.artificial.RPCInterfaceExample\"))).handledInheritedGenericIntDto(arg0);", responseDto.testScript.get(8));
         assertEquals("}", responseDto.testScript.get(9));

--- a/client-java/controller/src/test/java/org/evomaster/client/java/controller/problem/rpc/invocation/RPCSutControllerTest.java
+++ b/client-java/controller/src/test/java/org/evomaster/client/java/controller/problem/rpc/invocation/RPCSutControllerTest.java
@@ -100,6 +100,8 @@ public class RPCSutControllerTest {
         rpcController.executeAction(dto, responseDto);
         assertNull(responseDto.exceptionInfoDto);
         assertEquals(9, responseDto.testScript.size());
+        assertEquals(1, responseDto.assertionScript.size());
+        assertEquals("first", responseDto.rpcResponse.stringValue);
     }
 
     @Test

--- a/client-java/controller/src/test/java/org/evomaster/client/java/controller/problem/rpc/invocation/RPCSutControllerTest.java
+++ b/client-java/controller/src/test/java/org/evomaster/client/java/controller/problem/rpc/invocation/RPCSutControllerTest.java
@@ -8,6 +8,7 @@ import org.evomaster.client.java.controller.api.dto.problem.rpc.ParamDto;
 import org.evomaster.client.java.controller.api.dto.problem.rpc.RPCActionDto;
 import org.evomaster.client.java.controller.api.dto.problem.rpc.RPCInterfaceSchemaDto;
 import org.evomaster.client.java.controller.api.dto.problem.rpc.RPCSupportedDataType;
+import org.evomaster.client.java.controller.problem.rpc.schema.params.NamedTypedValue;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -77,6 +78,28 @@ public class RPCSutControllerTest {
         assertTrue(types.contains(NestedGenericDto.class.getName()+"<"+String.class.getName()+">"));
         assertTrue(types.contains(GenericDto.class.getName()+"<"+String.class.getName()+", "+Integer.class.getName()+">"));
 
+    }
+
+    @Test
+    public void testEnumWithConstructor(){
+        List<RPCActionDto> dtos = interfaceSchemas.get(0).endpoints.stream().filter(s-> s.actionName.equals("handleEnumWithConstructor")).collect(Collectors.toList());
+
+        assertEquals(1, dtos.size());
+        RPCActionDto dto = dtos.get(0).copy();
+        assertEquals(1, dto.requestParams.size());
+        dto.doGenerateAssertions = true;
+        dto.doGenerateTestScript = true;
+        dto.controllerVariable = "rpcController";
+        dto.responseVariable = "res1";
+
+        ActionResponseDto responseDto = new ActionResponseDto();
+
+        ParamDto param = dto.requestParams.get(0);
+        param.stringValue = "{}";
+        param.innerContent.get(0).stringValue="0";
+        rpcController.executeAction(dto, responseDto);
+        assertNull(responseDto.exceptionInfoDto);
+        assertEquals(9, responseDto.testScript.size());
     }
 
     @Test


### PR DESCRIPTION
fix some problems in test generation for industrial case studies
- enum with override `toString`
- handle setter with short and byte