### PR TITLE
fix problem with H2VERSION() in scout-api

### DIFF
--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/db/DbCleaner.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/db/DbCleaner.java
@@ -32,18 +32,19 @@ public class DbCleaner {
     }
 
     public static void clearDatabase_H2(Connection connection, String schemaName, List<String> tableToSkip, List<String> tableToClean) {
+        final String h2Version;
         try {
-            final String h2Version = H2VersionUtils.getH2Version(connection);
-            /*
-             * The SQL command "TRUNCATE TABLE my_table RESTART IDENTITY"
-             * is not supported by H2 version 1.4.199 or lower
-             */
-            final boolean restartIdentitiyWhenTruncating = H2VersionUtils.isVersionGreaterOrEqual(h2Version, H2VersionUtils.H2_VERSION_2_0_0);
-            clearDatabase(getDefaultRetries(DatabaseType.H2), connection, schemaName, tableToSkip, tableToClean, DatabaseType.H2,
-                    false, true, restartIdentitiyWhenTruncating);
+            h2Version = H2VersionUtils.getH2Version(connection);
         } catch (SQLException e) {
             throw new RuntimeException("Unexpected SQLException while fetching H2 version", e);
         }
+        /*
+         * The SQL command "TRUNCATE TABLE my_table RESTART IDENTITY"
+         * is not supported by H2 version 1.4.199 or lower
+         */
+        final boolean restartIdentitiyWhenTruncating = H2VersionUtils.isVersionGreaterOrEqual(h2Version, H2VersionUtils.H2_VERSION_2_0_0);
+        clearDatabase(getDefaultRetries(DatabaseType.H2), connection, schemaName, tableToSkip, tableToClean, DatabaseType.H2,
+                false, true, restartIdentitiyWhenTruncating);
     }
 
     /*

--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/db/h2/H2VersionUtils.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/db/h2/H2VersionUtils.java
@@ -40,11 +40,11 @@ public abstract class H2VersionUtils {
      */
     public static synchronized String getH2Version(Connection connectionToH2) throws SQLException {
         try (Statement statement = connectionToH2.createStatement()) {
-            final String query = "SELECT H2Version();";
+            final String query = "SELECT H2VERSION();";
             try (ResultSet columns = statement.executeQuery(query)) {
                 boolean hasNext = columns.next();
                 if (!hasNext) {
-                    throw new IllegalArgumentException("Cannot retrieve H2 version");
+                    throw new IllegalArgumentException("No results for query: SELECT H2VERSION();");
                 }
                 return columns.getString(COLUMN_INDEX_H2_VERSION);
             }


### PR DESCRIPTION
I was unable to reproduce the issue on my system (running a macOS Monterrey).
Could you please provide me more information on the fault in scout-api (i.e. stack trace of the nested exception)?

Cheers,
JP

ERROR - Unexpected SQLException while fetching H2 version
java.lang.RuntimeException: Unexpected SQLException while fetching H2 version
	at org.evomaster.client.java.controller.db.DbCleaner.clearDatabase_H2(DbCleaner.java:45)
	at org.evomaster.client.java.controller.db.DbCleaner.clearDatabase_H2(DbCleaner.java:31)
	at org.evomaster.client.java.controller.db.DbCleaner.clearDatabase_H2(DbCleaner.java:27)
	at org.evomaster.client.java.controller.db.DbCleaner.clearDatabase_H2(DbCleaner.java:23)
	at em.external.se.devscout.scoutapi.ExternalEvoMasterController.resetStateOfSUT(ExternalEvoMasterController.java:230)
	at em.external.se.devscout.scoutapi.ExternalEvoMasterController.postStart(ExternalEvoMasterController.java:205)
	at org.evomaster.client.java.controller.ExternalSutController.startSut(ExternalSutController.java:320)
	at org.evomaster.client.java.controller.internal.EMController.lambda$runSut$20(EMController.java:352)
	at org.evomaster.client.java.controller.internal.EMController.noKillSwitch(EMController.java:123)
	at org.evomaster.client.java.controller.internal.EMController.runSut(EMController.java:352)