### PR TITLE
Refactor JpaConstraint 

### DIFF
--- a/client-java/instrumentation/src/main/java/org/evomaster/client/java/instrumentation/JpaAnnotationName.java
+++ b/client-java/instrumentation/src/main/java/org/evomaster/client/java/instrumentation/JpaAnnotationName.java
@@ -1,0 +1,55 @@
+package org.evomaster.client.java.instrumentation;
+
+public class JpaAnnotationName {
+    public static final String JAVAX_PREFIX = "javax.";
+    public static final String JAKARTA_PREFIX = "jakarta.";
+    public static final String JAVAX_MAX_ANNOTATION_NAME = "javax.validation.constraints.Max";
+    public static final String JAKARTA_MAX_ANNOTATION_NAME = "jakarta.validation.constraints.Max";
+    public static final String JAVAX_MIN_ANNOTATION_NAME = "javax.validation.constraints.Min";
+    public static final String JAKARTA_MIN_ANNOTATION_NAME = "jakarta.validation.constraints.Min";
+    public static final String JAVAX_DECIMAL_MIN_ANNOTATION_NAME = "javax.validation.constraints.DecimalMin";
+    public static final String JAKARTA_DECIMAL_MIN_ANNOTATION_NAME = "jakarta.validation.constraints.DecimalMin";
+    public static final String JAVAX_DECIMAL_MAX_ANNOTATION_NAME = "javax.validation.constraints.DecimalMax";
+    public static final String JAKARTA_DECIMAL_MAX_ANNOTATION_NAME = "jakarta.validation.constraints.DecimalMax";
+    public static final String JAVAX_PATTERN_ANNOTATION_NAME = "javax.validation.constraints.Pattern";
+    public static final String JAKARTA_PATTERN_ANNOTATION_NAME = "jakarta.validation.constraints.Pattern";
+    public static final String JAVAX_NOT_BLANK_ANNOTATION_NAME = "javax.validation.constraints.NotBlank";
+    public static final String JAKARTA_NOT_BLANK_ANNOTATION_NAME = "jakarta.validation.constraints.NotBlank";
+    public static final String JAVAX_EMAIL_ANNOTATION_NAME = "javax.validation.constraints.Email";
+    public static final String JAKARTA_EMAIL_ANNOTATION_NAME = "jakarta.validation.constraints.Email";
+    public static final String JAVAX_NEGATIVE_ANNOTATION_NAME = "javax.validation.constraints.Negative";
+    public static final String JAKARTA_NEGATIVE_ANNOTATION_NAME = "jakarta.validation.constraints.Negative";
+    public static final String JAVAX_NEGATIVE_OR_ZERO_ANNOTATION_NAME = "javax.validation.constraints.NegativeOrZero";
+    public static final String JAKARTA_NEGATIVE_OR_ZERO_ANNOTATION_NAME = "jakarta.validation.constraints.NegativeOrZero";
+    public static final String JAVAX_POSITIVE_ANNOTATION_NAME = "javax.validation.constraints.Positive";
+    public static final String JAKARTA_POSITIVE_ANNOTATION_NAME = "jakarta.validation.constraints.Positive";
+    public static final String JAVAX_POSITIVE_OR_ZERO_ANNOTATION_NAME = "javax.validation.constraints.PositiveOrZero";
+    public static final String JAKARTA_POSITIVE_OR_ZERO_ANNOTATION_NAME = "jakarta.validation.constraints.PositiveOrZero";
+    public static final String JAVAX_PAST_ANNOTATION_NAME = "javax.validation.constraints.Past";
+    public static final String JAKARTA_PAST_ANNOTATION_NAME = "jakarta.validation.constraints.Past";
+    public static final String JAVAX_PAST_OR_PRESENT_ANNOTATION_NAME = "javax.validation.constraints.PastOrPresent";
+    public static final String JAKARTA_PAST_OR_PRESENT_ANNOTATION_NAME = "jakarta.validation.constraints.PastOrPresent";
+    public static final String JAVAX_FUTURE_ANNOTATION_NAME = "javax.validation.constraints.Future";
+    public static final String JAKARTA_FUTURE_ANNOTATION_NAME = "jakarta.validation.constraints.Future";
+    public static final String JAVAX_FUTURE_OR_PRESENT_ANNOTATION_NAME = "javax.validation.constraints.FutureOrPresent";
+    public static final String JAKARTA_FUTURE_OR_PRESENT_ANNOTATION_NAME = "jakarta.validation.constraints.FutureOrPresent";
+    public static final String JAVAX_NULL_ANNOTATION_NAME = "javax.validation.constraints.Null";
+    public static final String JAKARTA_NULL_ANNOTATION_NAME = "jakarta.validation.constraints.Null";
+    public static final String JAVAX_SIZE_ANNOTATION_NAME = "javax.validation.constraints.Size";
+    public static final String JAKARTA_SIZE_ANNOTATION_NAME = "jakarta.validation.constraints.Size";
+    public static final String JAVAX_DIGITS_ANNOTATION_NAME = "javax.validation.constraints.Digits";
+    public static final String JAKARTA_DIGITS_ANNOTATION_NAME = "jakarta.validation.constraints.Digits";
+    public static final String JAVAX_NOT_NULL_ANNOTATION_NAME = "javax.validation.constraints.NotNull";
+    public static final String JAKARTA_NOT_NULL_ANNOTATION_NAME = "jakarta.validation.constraints.NotNull";
+    public static final String JAVAX_ENTITY_ANNOTATION_NAME = "javax.persistence.Entity";
+    public static final String JAKARTA_ENTITY_ANNOTATION_NAME = "jakarta.persistence.Entity";
+    public static final String JAVAX_TABLE_ANNOTATION_NAME = "javax.persistence.Table";
+    public static final String JAKARTA_TABLE_ANNOTATION_NAME = "jakarta.persistence.Table";
+    public static final String JAVAX_COLUMN_ANNOTATION_NAME = "javax.persistence.Column";
+    public static final String JAKARTA_COLUMN_ANNOTATION_NAME = "jakarta.persistence.Column";
+    public static final String JAVAX_TRANSIENT_ANNOTATION_NAME = "javax.persistence.Transient";
+    public static final String JAKARTA_TRANSIENT_ANNOTATION_NAME = "jakarta.persistence.Transient";
+    public static final String JAVAX_ENUMERATED_ANNOTATION_NAME = "javax.persistence.Enumerated";
+    public static final String JAKARTA_ENUMERATED_ANNOTATION_NAME = "jakarta.persistence.Enumerated";
+
+}

--- a/client-java/instrumentation/src/main/java/org/evomaster/client/java/instrumentation/JpaConstraint.java
+++ b/client-java/instrumentation/src/main/java/org/evomaster/client/java/instrumentation/JpaConstraint.java
@@ -168,7 +168,6 @@ public class JpaConstraint implements Serializable {
                          Integer digitsFraction
     ) {
 
-
         this.tableName = Objects.requireNonNull(tableName);
         this.columnName = Objects.requireNonNull(columnName);
 
@@ -195,8 +194,6 @@ public class JpaConstraint implements Serializable {
         this.sizeMax = sizeMax;
         this.digitsInteger = digitsInteger;
         this.digitsFraction = digitsFraction;
-
-
     }
 
     public boolean isMeaningful() {

--- a/client-java/instrumentation/src/main/java/org/evomaster/client/java/instrumentation/JpaConstraintBuilder.java
+++ b/client-java/instrumentation/src/main/java/org/evomaster/client/java/instrumentation/JpaConstraintBuilder.java
@@ -1,0 +1,163 @@
+package org.evomaster.client.java.instrumentation;
+
+import java.util.List;
+
+public class JpaConstraintBuilder {
+    private String tableName;
+    private String columnName;
+    private Boolean isNullable;
+    private Boolean isOptional;
+    private Long minValue;
+    private Long maxValue;
+    private List<String> enumValuesAsStrings;
+    private String decimalMinValue;
+    private String decimalMaxValue;
+    private Boolean isNotBlank;
+    private Boolean isEmail;
+    private Boolean isNegative;
+    private Boolean isNegativeOrZero;
+    private Boolean isPositive;
+    private Boolean isPositiveOrZero;
+    private Boolean isFuture;
+    private Boolean isFutureOrPresent;
+    private Boolean isPast;
+    private Boolean isPastOrPresent;
+    private Boolean isAlwaysNull;
+    private String patternRegExp;
+    private Integer sizeMin;
+    private Integer sizeMax;
+    private Integer digitsInteger;
+    private Integer digitsFraction;
+
+    public JpaConstraintBuilder withTableName(String tableName) {
+        this.tableName = tableName;
+        return this;
+    }
+
+    public JpaConstraintBuilder withColumnName(String columnName) {
+        this.columnName = columnName;
+        return this;
+    }
+
+    public JpaConstraintBuilder withIsNullable(Boolean isNullable) {
+        this.isNullable = isNullable;
+        return this;
+    }
+
+    public JpaConstraintBuilder withIsOptional(Boolean isOptional) {
+        this.isOptional = isOptional;
+        return this;
+    }
+
+    public JpaConstraintBuilder withMinValue(Long minValue) {
+        this.minValue = minValue;
+        return this;
+    }
+
+    public JpaConstraintBuilder withMaxValue(Long maxValue) {
+        this.maxValue = maxValue;
+        return this;
+    }
+
+    public JpaConstraintBuilder withEnumValuesAsStrings(List<String> enumValuesAsStrings) {
+        this.enumValuesAsStrings = enumValuesAsStrings;
+        return this;
+    }
+
+    public JpaConstraintBuilder withDecimalMinValue(String decimalMinValue) {
+        this.decimalMinValue = decimalMinValue;
+        return this;
+    }
+
+    public JpaConstraintBuilder withDecimalMaxValue(String decimalMaxValue) {
+        this.decimalMaxValue = decimalMaxValue;
+        return this;
+    }
+
+    public JpaConstraintBuilder withIsNotBlank(Boolean isNotBlank) {
+        this.isNotBlank = isNotBlank;
+        return this;
+    }
+
+    public JpaConstraintBuilder withIsEmail(Boolean isEmail) {
+        this.isEmail = isEmail;
+        return this;
+    }
+
+    public JpaConstraintBuilder withIsNegative(Boolean isNegative) {
+        this.isNegative = isNegative;
+        return this;
+    }
+
+    public JpaConstraintBuilder withIsNegativeOrZero(Boolean isNegativeOrZero) {
+        this.isNegativeOrZero = isNegativeOrZero;
+        return this;
+    }
+
+    public JpaConstraintBuilder withIsPositive(Boolean isPositive) {
+        this.isPositive = isPositive;
+        return this;
+    }
+
+    public JpaConstraintBuilder withIsPositiveOrZero(Boolean isPositiveOrZero) {
+        this.isPositiveOrZero = isPositiveOrZero;
+        return this;
+    }
+
+    public JpaConstraintBuilder withIsFuture(Boolean isFuture) {
+        this.isFuture = isFuture;
+        return this;
+    }
+
+    public JpaConstraintBuilder withIsFutureOrPresent(Boolean isFutureOrPresent) {
+        this.isFutureOrPresent = isFutureOrPresent;
+        return this;
+    }
+
+    public JpaConstraintBuilder withIsPast(Boolean isPast) {
+        this.isPast = isPast;
+        return this;
+    }
+
+    public JpaConstraintBuilder withIsPastOrPresent(Boolean isPastOrPresent) {
+        this.isPastOrPresent = isPastOrPresent;
+        return this;
+    }
+
+    public JpaConstraintBuilder withIsAlwaysNull(Boolean isAlwaysNull) {
+        this.isAlwaysNull = isAlwaysNull;
+        return this;
+    }
+
+    public JpaConstraintBuilder withPatternRegExp(String patternRegExp) {
+        this.patternRegExp = patternRegExp;
+        return this;
+    }
+
+    public JpaConstraintBuilder withSizeMin(Integer sizeMin) {
+        this.sizeMin = sizeMin;
+        return this;
+    }
+
+    public JpaConstraintBuilder withSizeMax(Integer sizeMax) {
+        this.sizeMax = sizeMax;
+        return this;
+    }
+
+    public JpaConstraintBuilder withDigitsInteger(Integer digitsInteger) {
+        this.digitsInteger = digitsInteger;
+        return this;
+    }
+
+    public JpaConstraintBuilder withDigitsFraction(Integer digitsFraction) {
+        this.digitsFraction = digitsFraction;
+        return this;
+    }
+
+    public JpaConstraint createJpaConstraint() {
+        return new JpaConstraint(tableName, columnName, isNullable, isOptional, minValue, maxValue, enumValuesAsStrings,
+                decimalMinValue, decimalMaxValue, isNotBlank, isEmail, isNegative, isNegativeOrZero, isPositive,
+                isPositiveOrZero, isFuture, isFutureOrPresent, isPast, isPastOrPresent, isAlwaysNull, patternRegExp,
+                sizeMin, sizeMax, digitsInteger, digitsFraction);
+    }
+}

--- a/client-java/instrumentation/src/main/java/org/evomaster/client/java/instrumentation/NameSpace.java
+++ b/client-java/instrumentation/src/main/java/org/evomaster/client/java/instrumentation/NameSpace.java
@@ -1,0 +1,7 @@
+package org.evomaster.client.java.instrumentation;
+
+/**
+ * Indicates if the Java Persistence API (jpa) is being used (with prefix javax.*) or
+ * the Jakarta Persistence Layer (with prefix jakarta.*) is being used.
+ */
+public enum NameSpace {JAVAX, JAKARTA}

--- a/client-java/instrumentation/src/main/java/org/evomaster/client/java/instrumentation/staticstate/UnitsInfoRecorder.java
+++ b/client-java/instrumentation/src/main/java/org/evomaster/client/java/instrumentation/staticstate/UnitsInfoRecorder.java
@@ -195,8 +195,8 @@ public class UnitsInfoRecorder implements Serializable {
 
         /*
             Tricky, could not find a good way to intercept where classes are loaded...
-            when using transformation in Agent , we can intercept _before_ loading, but not _after_.
-            so, here we do it lazily, by forcing loading on get()
+            when using transformation in Agent, we can intercept _before_ loading, but not _after_.
+            So, here we do it lazily, by forcing loading on get()
          */
         if(!analyzedClasses){
             ClassAnalyzer.doAnalyze(unitNames);


### PR DESCRIPTION
This PR includes only refactors and no change in functionality.
- Refactor in `ClassAnalyzer` which includes:
  - Moving annotation names into another file
  - Modified `getAnnotationName` method to remove validation of namespace not null outside
- Created a builder for `JpaConstraint`: `JpaConstraintBuilder` to avoid having a constructor with so many parameters
- Refactor `ClassAnalyzerTest` to have a `@BeforeEach` setup