### PR TITLE
Fixing the issue: #759

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/Main.kt
+++ b/core/src/main/kotlin/org/evomaster/core/Main.kt
@@ -13,6 +13,7 @@ import org.evomaster.core.AnsiColor.Companion.inYellow
 import org.evomaster.core.config.ConfigProblemException
 import org.evomaster.core.logging.LoggingUtil
 import org.evomaster.core.output.OutputFormat
+import org.evomaster.core.output.Termination
 import org.evomaster.core.output.TestSuiteSplitter
 import org.evomaster.core.output.clustering.SplitResult
 import org.evomaster.core.output.service.TestSuiteWriter
@@ -698,7 +699,14 @@ class Main {
                     .forEach { writer.writeTests(it, controllerInfoDto?.fullName,controllerInfoDto?.executableFullPath, snapshot) }
 
                 if (config.executiveSummary) {
-                    writeExecSummary(injector, controllerInfoDto, splitResult)
+
+                    // Onur - if there are fault cases, executive summary makes sense
+                    if ( splitResult.splitOutcome.any{ it.individuals.isNotEmpty()
+                                && it.termination != Termination.SUCCESSES}) {
+                        writeExecSummary(injector, controllerInfoDto, splitResult)
+                    }
+
+                    //writeExecSummary(injector, controllerInfoDto, splitResult)
                     //writeExecutiveSummary(injector, solution, controllerInfoDto, partialOracles)
                 }
             } else if (config.problemType == EMConfig.ProblemType.RPC){

--- a/core/src/main/kotlin/org/evomaster/core/output/TestSuiteSplitter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/TestSuiteSplitter.kt
@@ -90,9 +90,28 @@ object TestSuiteSplitter {
 
         // BMR: Splitting support for new problems
         val sol = if(config.problemType == EMConfig.ProblemType.GRAPHQL){
-            solution as Solution<GraphQLIndividual>
+            //solution as Solution<GraphQLIndividual>
+
+            Solution(
+                solution.individuals as MutableList<EvaluatedIndividual<GraphQLIndividual>>,
+                solution.testSuiteNamePrefix,
+                solution.testSuiteNameSuffix,
+                Termination.SUMMARY,
+                solution.individualsDuringSeeding as List<EvaluatedIndividual<GraphQLIndividual>>,
+                solution.targetsDuringSeeding
+            )
+
         } else {
-            solution as Solution<RestIndividual>
+            //solution as Solution<RestIndividual>
+
+            Solution(
+                solution.individuals as MutableList<EvaluatedIndividual<RestIndividual>>,
+                solution.testSuiteNamePrefix,
+                solution.testSuiteNameSuffix,
+                Termination.SUMMARY,
+                solution.individualsDuringSeeding as List<EvaluatedIndividual<RestIndividual>>,
+                solution.targetsDuringSeeding
+            )
         }
         val metrics = mutableListOf(DistanceMetricErrorText(config.errorTextEpsilon), DistanceMetricLastLine(config.lastLineEpsilon))
         val errs = sol.individuals.filter {ind ->

--- a/core/src/main/kotlin/org/evomaster/core/output/TestSuiteSplitter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/TestSuiteSplitter.kt
@@ -90,28 +90,9 @@ object TestSuiteSplitter {
 
         // BMR: Splitting support for new problems
         val sol = if(config.problemType == EMConfig.ProblemType.GRAPHQL){
-            //solution as Solution<GraphQLIndividual>
-
-            Solution(
-                solution.individuals as MutableList<EvaluatedIndividual<GraphQLIndividual>>,
-                solution.testSuiteNamePrefix,
-                solution.testSuiteNameSuffix,
-                Termination.SUMMARY,
-                solution.individualsDuringSeeding as List<EvaluatedIndividual<GraphQLIndividual>>,
-                solution.targetsDuringSeeding
-            )
-
+            solution as Solution<GraphQLIndividual>
         } else {
-            //solution as Solution<RestIndividual>
-
-            Solution(
-                solution.individuals as MutableList<EvaluatedIndividual<RestIndividual>>,
-                solution.testSuiteNamePrefix,
-                solution.testSuiteNameSuffix,
-                Termination.SUMMARY,
-                solution.individualsDuringSeeding as List<EvaluatedIndividual<RestIndividual>>,
-                solution.targetsDuringSeeding
-            )
+            solution as Solution<RestIndividual>
         }
         val metrics = mutableListOf(DistanceMetricErrorText(config.errorTextEpsilon), DistanceMetricLastLine(config.lastLineEpsilon))
         val errs = sol.individuals.filter {ind ->
@@ -132,7 +113,7 @@ object TestSuiteSplitter {
                 if(errs.size <= 1){
                     splitResult.splitOutcome = splitByCode(sol, config)
                     // TODO: BMR - what is the executive summary behaviour for 1 or fewer errors?
-                    splitResult.executiveSummary = sol
+                    splitResult.executiveSummary = sol.convertSolutionToExecutiveSummary()
                 } else {
                     val clusters = conductClustering(sol as Solution<ApiWsIndividual>, oracles, config, metrics, splitResult)
                     splitByCluster(clusters, sol, oracles, splitResult, config)

--- a/core/src/main/kotlin/org/evomaster/core/output/TestSuiteSplitter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/TestSuiteSplitter.kt
@@ -112,7 +112,10 @@ object TestSuiteSplitter {
             EMConfig.TestSuiteSplitType.CLUSTER -> {
                 if(errs.size <= 1){
                     splitResult.splitOutcome = splitByCode(sol, config)
+
                     // TODO: BMR - what is the executive summary behaviour for 1 or fewer errors?
+                    // Onur - Executive summary gets all success cases in case there are no faults.
+                    // So if the executive summary gets all success cases, it should not be shown.
                     splitResult.executiveSummary = sol.convertSolutionToExecutiveSummary()
                 } else {
                     val clusters = conductClustering(sol as Solution<ApiWsIndividual>, oracles, config, metrics, splitResult)

--- a/core/src/main/kotlin/org/evomaster/core/search/Solution.kt
+++ b/core/src/main/kotlin/org/evomaster/core/search/Solution.kt
@@ -66,4 +66,12 @@ where T : Individual {
     fun extractSolutionDuringSeeding() : Solution<T>{
         return Solution(individualsDuringSeeding.toMutableList(), testSuiteNamePrefix, testSuiteNameSuffix, Termination.SEEDING, listOf(), listOf())
     }
+
+    /**
+     * Add a function which sets the termination criteria
+     */
+    fun convertSolutionToExecutiveSummary() : Solution<T> {
+        return Solution(individuals, testSuiteNamePrefix, testSuiteNameSuffix, Termination.SUMMARY,
+            individualsDuringSeeding, targetsDuringSeeding)
+    }
 }

--- a/e2e-tests/spring-rest-openapi-v2/src/main/java/com/foo/rest/examples/spring/filecreationissuenofault/FileCreationIssueNoFaultApplication.java
+++ b/e2e-tests/spring-rest-openapi-v2/src/main/java/com/foo/rest/examples/spring/filecreationissuenofault/FileCreationIssueNoFaultApplication.java
@@ -1,0 +1,16 @@
+package com.foo.rest.examples.spring.filecreationissuenofault;
+
+import com.foo.rest.examples.spring.SwaggerConfiguration;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@EnableSwagger2
+@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
+public class FileCreationIssueNoFaultApplication extends SwaggerConfiguration {
+
+    public static void main(String[] args) {
+        SpringApplication.run(FileCreationIssueNoFaultApplication.class, args);
+    }
+}

--- a/e2e-tests/spring-rest-openapi-v2/src/main/java/com/foo/rest/examples/spring/filecreationissuenofault/FileCreationIssueNoFaultRest.java
+++ b/e2e-tests/spring-rest-openapi-v2/src/main/java/com/foo/rest/examples/spring/filecreationissuenofault/FileCreationIssueNoFaultRest.java
@@ -1,0 +1,16 @@
+package com.foo.rest.examples.spring.filecreationissuenofault;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping(path = "/api")
+public class FileCreationIssueNoFaultRest {
+
+    @GetMapping(value = "/{x}")
+    public ResponseEntity getResource(@PathVariable("x") String x) {
+
+        return ResponseEntity.status(HttpStatus.OK).body(x);
+    }
+}

--- a/e2e-tests/spring-rest-openapi-v2/src/main/java/com/foo/rest/examples/spring/filecreationissuewithfault/FileCreationIssueWithFaultApplication.java
+++ b/e2e-tests/spring-rest-openapi-v2/src/main/java/com/foo/rest/examples/spring/filecreationissuewithfault/FileCreationIssueWithFaultApplication.java
@@ -1,0 +1,16 @@
+package com.foo.rest.examples.spring.filecreationissuewithfault;
+
+import com.foo.rest.examples.spring.SwaggerConfiguration;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@EnableSwagger2
+@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
+public class FileCreationIssueWithFaultApplication extends SwaggerConfiguration {
+
+    public static void main(String[] args) {
+        SpringApplication.run(FileCreationIssueWithFaultApplication.class, args);
+    }
+}

--- a/e2e-tests/spring-rest-openapi-v2/src/main/java/com/foo/rest/examples/spring/filecreationissuewithfault/FileCreationIssueWithFaultRest.java
+++ b/e2e-tests/spring-rest-openapi-v2/src/main/java/com/foo/rest/examples/spring/filecreationissuewithfault/FileCreationIssueWithFaultRest.java
@@ -1,0 +1,29 @@
+package com.foo.rest.examples.spring.filecreationissuewithfault;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping(path = "/api")
+public class FileCreationIssueWithFaultRest {
+
+    @GetMapping(value = "/{x}")
+    public ResponseEntity getResource(@PathVariable("x") String x) {
+
+        return ResponseEntity.status(HttpStatus.OK).body(x);
+    }
+
+    @PostMapping(value = "/{x}")
+    public ResponseEntity postResource(@PathVariable("x") String x) {
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(x);
+    }
+
+    @PutMapping(value = "/{x}")
+    public ResponseEntity putResource(@PathVariable("x") String x) {
+
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(x);
+    }
+
+}

--- a/e2e-tests/spring-rest-openapi-v2/src/test/java/com/foo/rest/examples/spring/filecreationissuenofault/FileCreationIssueNoFaultController.java
+++ b/e2e-tests/spring-rest-openapi-v2/src/test/java/com/foo/rest/examples/spring/filecreationissuenofault/FileCreationIssueNoFaultController.java
@@ -1,0 +1,11 @@
+package com.foo.rest.examples.spring.filecreationissuenofault;
+
+import com.foo.rest.examples.spring.SpringController;
+
+public class FileCreationIssueNoFaultController extends SpringController {
+
+    public FileCreationIssueNoFaultController(){
+        super(FileCreationIssueNoFaultApplication.class);
+    }
+
+}

--- a/e2e-tests/spring-rest-openapi-v2/src/test/java/com/foo/rest/examples/spring/filecreationissuewithfault/FileCreationIssueWithFaultController.java
+++ b/e2e-tests/spring-rest-openapi-v2/src/test/java/com/foo/rest/examples/spring/filecreationissuewithfault/FileCreationIssueWithFaultController.java
@@ -1,0 +1,11 @@
+package com.foo.rest.examples.spring.filecreationissuewithfault;
+
+import com.foo.rest.examples.spring.SpringController;
+
+public class FileCreationIssueWithFaultController extends SpringController {
+
+    public FileCreationIssueWithFaultController(){
+        super(FileCreationIssueWithFaultApplication.class);
+    }
+
+}

--- a/e2e-tests/spring-rest-openapi-v2/src/test/java/org/evomaster/e2etests/spring/examples/filecreationissue/FileCreationIssueEMTest.java
+++ b/e2e-tests/spring-rest-openapi-v2/src/test/java/org/evomaster/e2etests/spring/examples/filecreationissue/FileCreationIssueEMTest.java
@@ -1,0 +1,174 @@
+package org.evomaster.e2etests.spring.examples.filecreationissue;
+
+import com.foo.rest.examples.spring.endpointfilter.EndpointFilterController;
+import com.foo.rest.examples.spring.endpointfocusandprefix.EndpointFocusAndPrefixController;
+import org.evomaster.core.problem.rest.HttpVerb;
+import org.evomaster.core.problem.rest.RestIndividual;
+import org.evomaster.core.search.Solution;
+import org.evomaster.e2etests.spring.examples.SpringTestBase;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class FileCreationIssueEMTest extends SpringTestBase {
+
+    @BeforeAll
+    public static void initClass() throws Exception {
+
+        SpringTestBase.initClass(new EndpointFocusAndPrefixController());
+    }
+
+    /**
+     * If executive summary is requested, the name of the file should be
+     * EvoMaster_fault_representatives_Test.java, there should not be a file
+     * with name EvoMaster_Test.java
+     * @throws Throwable
+     */
+    @Test
+    public void testFileCreationIssueWithSummary() throws Throwable {
+
+        File outFolder = null;
+
+        try {
+
+            String outFolderName = "fileCreationIssueTest";
+
+            List args = new ArrayList<String>();
+
+            args.add("--blackBox");
+            args.add("true");
+            args.add("--bbTargetUrl");
+            args.add(baseUrlOfSut);
+            args.add("--bbSwaggerUrl");
+            args.add(baseUrlOfSut + "/v2/api-docs");
+            args.add("--outputFormat");
+            args.add("JAVA_JUNIT_4");
+            args.add("--outputFolder");
+            args.add(outFolderName);
+            args.add("--executiveSummary");
+            args.add("true");
+            args.add("--maxTime");
+            args.add("30s");
+
+            // run evomaster
+            initAndRun(args);
+
+            // check that the folder org/foo/FileCreationIssue contains the file: EvoMaster_fault_representatives_Test
+            // and does not contain the file EvoMaster_Test.java
+            String currentDir = System.getProperty("user.dir");
+
+            String filePath = currentDir + "/" + outFolderName;
+
+            outFolder = new File(filePath);
+
+            Assert.assertTrue(outFolder.exists() && outFolder.isDirectory());
+
+            String files[] = outFolder.list();
+
+            boolean summaryFound = false;
+            boolean emptyFound = false;
+
+            for (String s : files) {
+                if (s.equals("EvoMaster_fault_representatives_Test.java")) {
+                    summaryFound = true;
+                } else if (s.equals("EvoMaster_Test.java")) {
+                    emptyFound = true;
+                }
+            }
+
+            // summary should be found, empty should not be found
+            Assert.assertTrue(summaryFound);
+            Assert.assertFalse(emptyFound);
+        } catch(Exception e) {
+            e.printStackTrace();
+        } finally {
+            if (outFolder != null) {
+                if(outFolder.exists()) {
+                    FileUtils.deleteDirectory(outFolder);
+                }
+            }
+        }
+
+
+    }
+
+    /**
+     * If executive summary is not requested, there should not be a file with name
+     * EvoMaster_fault_representatives_Test.java, and there should not be a file
+     * with name EvoMaster_Test.java
+     * @throws Throwable
+     */
+    @Test
+    public void testFileCreationIssueWithoutSummary() throws Throwable {
+
+        File outFolder = null;
+
+        try {
+
+            String outFolderName = "fileCreationIssueTest";
+
+            List args = new ArrayList<String>();
+
+            args.add("--blackBox");
+            args.add("true");
+            args.add("--bbTargetUrl");
+            args.add(baseUrlOfSut);
+            args.add("--bbSwaggerUrl");
+            args.add(baseUrlOfSut + "/v2/api-docs");
+            args.add("--outputFormat");
+            args.add("JAVA_JUNIT_4");
+            args.add("--outputFolder");
+            args.add(outFolderName);
+            args.add("--executiveSummary");
+            args.add("false");
+            args.add("--maxTime");
+            args.add("30s");
+
+            // run evomaster
+            initAndRun(args);
+
+            // check that the folder org/foo/FileCreationIssue contains the file: EvoMaster_fault_representatives_Test
+            // and does not contain the file EvoMaster_Test.java
+            String currentDir = System.getProperty("user.dir");
+
+            String filePath = currentDir + "/" + outFolderName;
+
+            outFolder = new File(filePath);
+
+            Assert.assertTrue(outFolder.exists() && outFolder.isDirectory());
+
+            String files[] = outFolder.list();
+
+            boolean summaryFound = false;
+            boolean emptyFound = false;
+
+            for (String s : files) {
+                if (s.equals("EvoMaster_fault_representatives_Test.java")) {
+                    summaryFound = true;
+                } else if (s.equals("EvoMaster_Test.java")) {
+                    emptyFound = true;
+                }
+            }
+
+            // summary should be found, empty should not be found
+            Assert.assertFalse(summaryFound);
+            Assert.assertFalse(emptyFound);
+        } catch(Exception e) {
+            e.printStackTrace();
+        } finally {
+            if (outFolder != null) {
+                if(outFolder.exists()) {
+                    FileUtils.deleteDirectory(outFolder);
+                }
+            }
+        }
+    }
+}

--- a/e2e-tests/spring-rest-openapi-v2/src/test/java/org/evomaster/e2etests/spring/examples/filecreationissue/FileCreationIssueFaultEMTest.java
+++ b/e2e-tests/spring-rest-openapi-v2/src/test/java/org/evomaster/e2etests/spring/examples/filecreationissue/FileCreationIssueFaultEMTest.java
@@ -50,7 +50,7 @@ public class FileCreationIssueFaultEMTest extends SpringTestBase {
             args.add("--executiveSummary");
             args.add("true");
             args.add("--maxTime");
-            args.add("10s");
+            args.add("5s");
 
             // run evomaster
             Solution sol = initAndRun(args);
@@ -111,7 +111,7 @@ public class FileCreationIssueFaultEMTest extends SpringTestBase {
             args.add("--executiveSummary");
             args.add("false");
             args.add("--maxTime");
-            args.add("10s");
+            args.add("5s");
 
             // run evomaster
             Solution sol = initAndRun(args);

--- a/e2e-tests/spring-rest-openapi-v2/src/test/java/org/evomaster/e2etests/spring/examples/filecreationissue/FileCreationIssueFaultEMTest.java
+++ b/e2e-tests/spring-rest-openapi-v2/src/test/java/org/evomaster/e2etests/spring/examples/filecreationissue/FileCreationIssueFaultEMTest.java
@@ -1,0 +1,146 @@
+package org.evomaster.e2etests.spring.examples.filecreationissue;
+
+import com.foo.rest.examples.spring.filecreationissuewithfault.FileCreationIssueWithFaultController;
+import org.evomaster.core.search.Solution;
+import org.evomaster.e2etests.spring.examples.SpringTestBase;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FileCreationIssueFaultEMTest extends SpringTestBase {
+
+    @BeforeAll
+    public static void initClass() throws Exception {
+
+        SpringTestBase.initClass(new FileCreationIssueWithFaultController());
+    }
+
+    /**
+     * If executive summary is requested, the name of the file should be
+     * EvoMaster_fault_representatives_Test.java, there should not be a file
+     * with name EvoMaster_Test.java
+     * @throws Throwable - exception is thrown and test fails if the outputFolder is not a folder.
+     */
+    @Test
+    public void testFileCreationIssueWithSummary() throws Throwable {
+
+        File outFolder = null;
+
+        try {
+
+            String outFolderName = "fileCreationIssueTest";
+
+            List<String> args = new ArrayList<>();
+
+            args.add("--blackBox");
+            args.add("true");
+            args.add("--bbTargetUrl");
+            args.add(baseUrlOfSut);
+            args.add("--bbSwaggerUrl");
+            args.add(baseUrlOfSut + "/v2/api-docs");
+            args.add("--outputFormat");
+            args.add("JAVA_JUNIT_4");
+            args.add("--outputFolder");
+            args.add(outFolderName);
+            args.add("--executiveSummary");
+            args.add("true");
+            args.add("--maxTime");
+            args.add("10s");
+
+            // run evomaster
+            Solution sol = initAndRun(args);
+
+            // check that the folder org/foo/FileCreationIssue contains the file: EvoMaster_fault_representatives_Test
+            // and does not contain the file EvoMaster_Test.java
+            String currentDir = System.getProperty("user.dir");
+
+            String filePath = currentDir + "/" + outFolderName;
+
+            outFolder = new File(filePath);
+
+            // if we are testing with faults, summary file is expected but the empty file is not
+            // expected.
+            Assert.assertTrue(
+                    FileCreationIssueTestHelper.checkExistenceOfRelevantFilesInDirectory(
+                            outFolder,
+                            sol.getTestSuiteNamePrefix(),
+                            sol.getTestSuiteNameSuffix(),
+                            true,
+                            false));
+        } finally {
+            if (outFolder != null) {
+                if(outFolder.exists()) {
+                    FileUtils.deleteDirectory(outFolder);
+                }
+            }
+        }
+    }
+
+    /**
+     * If executive summary is not requested, there should not be a file with name
+     * EvoMaster_fault_representatives_Test.java, and there should not be a file
+     * with name EvoMaster_Test.java
+     * @throws Throwable - exception is thrown and test fails if the outputFolder is not a folder.
+     */
+    @Test
+    public void testFileCreationIssueWithoutSummary() throws Throwable {
+
+        File outFolder = null;
+
+        try {
+
+            String outFolderName = "fileCreationIssueTest";
+
+            List<String> args = new ArrayList<>();
+
+            args.add("--blackBox");
+            args.add("true");
+            args.add("--bbTargetUrl");
+            args.add(baseUrlOfSut);
+            args.add("--bbSwaggerUrl");
+            args.add(baseUrlOfSut + "/v2/api-docs");
+            args.add("--outputFormat");
+            args.add("JAVA_JUNIT_4");
+            args.add("--outputFolder");
+            args.add(outFolderName);
+            args.add("--executiveSummary");
+            args.add("false");
+            args.add("--maxTime");
+            args.add("10s");
+
+            // run evomaster
+            Solution sol = initAndRun(args);
+
+            // check that the folder org/foo/FileCreationIssue contains the file: EvoMaster_fault_representatives_Test
+            // and does not contain the file EvoMaster_Test.java
+            String currentDir = System.getProperty("user.dir");
+
+            String filePath = currentDir + "/" + outFolderName;
+
+            outFolder = new File(filePath);
+
+            // if we are testing with faults, summary file is expected but the empty file is not
+            // expected.
+            Assert.assertTrue(
+                    FileCreationIssueTestHelper.checkExistenceOfRelevantFilesInDirectory(
+                            outFolder,
+                            sol.getTestSuiteNamePrefix(),
+                            sol.getTestSuiteNameSuffix(),
+                            false,
+                            false));
+
+
+        } finally {
+            if (outFolder != null) {
+                if(outFolder.exists()) {
+                    FileUtils.deleteDirectory(outFolder);
+                }
+            }
+        }
+    }
+}

--- a/e2e-tests/spring-rest-openapi-v2/src/test/java/org/evomaster/e2etests/spring/examples/filecreationissue/FileCreationIssueNoFaultEMTest.java
+++ b/e2e-tests/spring-rest-openapi-v2/src/test/java/org/evomaster/e2etests/spring/examples/filecreationissue/FileCreationIssueNoFaultEMTest.java
@@ -50,7 +50,7 @@ public class FileCreationIssueNoFaultEMTest extends SpringTestBase {
             args.add("--executiveSummary");
             args.add("true");
             args.add("--maxTime");
-            args.add("10s");
+            args.add("5s");
 
             // run evomaster
             Solution sol = initAndRun(args);
@@ -110,7 +110,7 @@ public class FileCreationIssueNoFaultEMTest extends SpringTestBase {
             args.add("--executiveSummary");
             args.add("false");
             args.add("--maxTime");
-            args.add("10s");
+            args.add("5s");
 
             // run evomaster
             Solution sol = initAndRun(args);

--- a/e2e-tests/spring-rest-openapi-v2/src/test/java/org/evomaster/e2etests/spring/examples/filecreationissue/FileCreationIssueNoFaultEMTest.java
+++ b/e2e-tests/spring-rest-openapi-v2/src/test/java/org/evomaster/e2etests/spring/examples/filecreationissue/FileCreationIssueNoFaultEMTest.java
@@ -1,9 +1,6 @@
 package org.evomaster.e2etests.spring.examples.filecreationissue;
 
-import com.foo.rest.examples.spring.endpointfilter.EndpointFilterController;
-import com.foo.rest.examples.spring.endpointfocusandprefix.EndpointFocusAndPrefixController;
-import org.evomaster.core.problem.rest.HttpVerb;
-import org.evomaster.core.problem.rest.RestIndividual;
+import com.foo.rest.examples.spring.filecreationissuenofault.FileCreationIssueNoFaultController;
 import org.evomaster.core.search.Solution;
 import org.evomaster.e2etests.spring.examples.SpringTestBase;
 import org.junit.Assert;
@@ -15,22 +12,19 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-public class FileCreationIssueEMTest extends SpringTestBase {
+public class FileCreationIssueNoFaultEMTest extends SpringTestBase {
 
     @BeforeAll
     public static void initClass() throws Exception {
 
-        SpringTestBase.initClass(new EndpointFocusAndPrefixController());
+        SpringTestBase.initClass(new FileCreationIssueNoFaultController());
     }
 
     /**
      * If executive summary is requested, the name of the file should be
      * EvoMaster_fault_representatives_Test.java, there should not be a file
      * with name EvoMaster_Test.java
-     * @throws Throwable
+     * @throws Throwable - if the outputFolder is not a folder, an exception is thrown and test fails.
      */
     @Test
     public void testFileCreationIssueWithSummary() throws Throwable {
@@ -41,7 +35,7 @@ public class FileCreationIssueEMTest extends SpringTestBase {
 
             String outFolderName = "fileCreationIssueTest";
 
-            List args = new ArrayList<String>();
+            List<String> args = new ArrayList<>();
 
             args.add("--blackBox");
             args.add("true");
@@ -56,10 +50,10 @@ public class FileCreationIssueEMTest extends SpringTestBase {
             args.add("--executiveSummary");
             args.add("true");
             args.add("--maxTime");
-            args.add("30s");
+            args.add("10s");
 
             // run evomaster
-            initAndRun(args);
+            Solution sol = initAndRun(args);
 
             // check that the folder org/foo/FileCreationIssue contains the file: EvoMaster_fault_representatives_Test
             // and does not contain the file EvoMaster_Test.java
@@ -69,26 +63,14 @@ public class FileCreationIssueEMTest extends SpringTestBase {
 
             outFolder = new File(filePath);
 
-            Assert.assertTrue(outFolder.exists() && outFolder.isDirectory());
-
-            String files[] = outFolder.list();
-
-            boolean summaryFound = false;
-            boolean emptyFound = false;
-
-            for (String s : files) {
-                if (s.equals("EvoMaster_fault_representatives_Test.java")) {
-                    summaryFound = true;
-                } else if (s.equals("EvoMaster_Test.java")) {
-                    emptyFound = true;
-                }
-            }
-
-            // summary should be found, empty should not be found
-            Assert.assertTrue(summaryFound);
-            Assert.assertFalse(emptyFound);
-        } catch(Exception e) {
-            e.printStackTrace();
+            // if we are testing without faults, summary file is not expected
+            Assert.assertTrue(
+                    FileCreationIssueTestHelper.checkExistenceOfRelevantFilesInDirectory(
+                            outFolder,
+                            sol.getTestSuiteNamePrefix(),
+                            sol.getTestSuiteNameSuffix(),
+                            false,
+                            false));
         } finally {
             if (outFolder != null) {
                 if(outFolder.exists()) {
@@ -96,8 +78,6 @@ public class FileCreationIssueEMTest extends SpringTestBase {
                 }
             }
         }
-
-
     }
 
     /**
@@ -115,7 +95,7 @@ public class FileCreationIssueEMTest extends SpringTestBase {
 
             String outFolderName = "fileCreationIssueTest";
 
-            List args = new ArrayList<String>();
+            List<String> args = new ArrayList<>();
 
             args.add("--blackBox");
             args.add("true");
@@ -130,10 +110,10 @@ public class FileCreationIssueEMTest extends SpringTestBase {
             args.add("--executiveSummary");
             args.add("false");
             args.add("--maxTime");
-            args.add("30s");
+            args.add("10s");
 
             // run evomaster
-            initAndRun(args);
+            Solution sol = initAndRun(args);
 
             // check that the folder org/foo/FileCreationIssue contains the file: EvoMaster_fault_representatives_Test
             // and does not contain the file EvoMaster_Test.java
@@ -143,26 +123,14 @@ public class FileCreationIssueEMTest extends SpringTestBase {
 
             outFolder = new File(filePath);
 
-            Assert.assertTrue(outFolder.exists() && outFolder.isDirectory());
-
-            String files[] = outFolder.list();
-
-            boolean summaryFound = false;
-            boolean emptyFound = false;
-
-            for (String s : files) {
-                if (s.equals("EvoMaster_fault_representatives_Test.java")) {
-                    summaryFound = true;
-                } else if (s.equals("EvoMaster_Test.java")) {
-                    emptyFound = true;
-                }
-            }
-
-            // summary should be found, empty should not be found
-            Assert.assertFalse(summaryFound);
-            Assert.assertFalse(emptyFound);
-        } catch(Exception e) {
-            e.printStackTrace();
+            // if we are testing without faults, summary file is not expected
+            Assert.assertTrue(
+                    FileCreationIssueTestHelper.checkExistenceOfRelevantFilesInDirectory(
+                            outFolder,
+                            sol.getTestSuiteNamePrefix(),
+                            sol.getTestSuiteNameSuffix(),
+                            false,
+                            false));
         } finally {
             if (outFolder != null) {
                 if(outFolder.exists()) {

--- a/e2e-tests/spring-rest-openapi-v2/src/test/java/org/evomaster/e2etests/spring/examples/filecreationissue/FileCreationIssueTestHelper.java
+++ b/e2e-tests/spring-rest-openapi-v2/src/test/java/org/evomaster/e2etests/spring/examples/filecreationissue/FileCreationIssueTestHelper.java
@@ -1,0 +1,69 @@
+package org.evomaster.e2etests.spring.examples.filecreationissue;
+
+import org.evomaster.core.output.Termination;
+
+import java.io.File;
+
+/**
+ * This is a simple class for avoiding code duplication in the test cases of file creation issue.
+ */
+public class FileCreationIssueTestHelper {
+
+    /**
+     * This method checks if the executive summary file and the empty
+     * @param directory - directory containing test files.
+     * @param filenamePrefix - Prefix of the filename
+     * @param filenameSuffix - Suffix of the filename
+     * @param summaryFileExpected
+     * @param emptyFileExpected
+     * @return
+     */
+    public static boolean checkExistenceOfRelevantFilesInDirectory(File directory,
+                                                                   String filenamePrefix,
+                                                                   String filenameSuffix,
+                                                                   boolean summaryFileExpected,
+                                                                   boolean emptyFileExpected) {
+
+
+        // if the directory does not exist or if it is not a directory
+        if (!directory.exists() || !directory.isDirectory()) {
+            throw new RuntimeException("Directory " + directory + " does not exist or is not a directory");
+        }
+        else {
+            // files in the current directory
+            File[] files = directory.listFiles();
+
+            // summary and empty found
+            boolean summaryFound = false;
+            boolean emptyFound = false;
+
+            // filename
+            String fileName = "";
+
+            for (File f : files) {
+
+                fileName = f.getName();
+
+                if (fileName.contains(filenamePrefix + "_" + filenameSuffix)) {
+                    emptyFound = true;
+                }
+                else if (fileName.contains(filenamePrefix + Termination.SUMMARY.getSuffix() + "_" + filenameSuffix)) {
+                    summaryFound = true;
+                }
+
+            }
+            // check with expected values.
+            if (emptyFound == emptyFileExpected && summaryFound == summaryFileExpected) {
+                return true;
+            }
+            else {
+                return false;
+            }
+
+        }
+
+
+
+    }
+
+}


### PR DESCRIPTION
https://github.com/EMResearch/EvoMaster/issues/759

By fixing the split method inside TestSuiteSplitter.kt.

Solution is not taken as it is for the executive summary. It is taken as everything being copied except Termination condition. By default, the solution object has the termination condition NONE. In this case, I changed it to Termination.SUMMARY.