### PR TITLE
Refactor Solver to use db schema

### DIFF
--- a/solver/src/main/java/DbConstraintSolver.java
+++ b/solver/src/main/java/DbConstraintSolver.java
@@ -1,3 +1,4 @@
+import org.evomaster.client.java.controller.api.dto.database.schema.DbSchemaDto;
 import org.evomaster.client.java.sql.internal.constraint.DbTableConstraint;
 import org.evomaster.core.sql.SqlAction;
 import org.evomaster.core.sql.schema.Table;
@@ -12,8 +13,7 @@ public interface DbConstraintSolver extends AutoCloseable {
 
     /**
      * Solves the given constraints and returns the Db Gene to insert in the database
-     * @param constraintList list of database constraints
      * @return a list of SQLAction with the inserts in the db for the given constraints
      */
-    List<SqlAction> solve(List<DbTableConstraint> constraintList);
+    List<SqlAction> solve();
 }

--- a/solver/src/main/java/DbConstraintSolverZ3InDocker.java
+++ b/solver/src/main/java/DbConstraintSolverZ3InDocker.java
@@ -1,10 +1,12 @@
 import org.evomaster.client.java.controller.api.dto.database.schema.DbSchemaDto;
+import org.evomaster.client.java.controller.api.dto.database.schema.TableDto;
 import org.evomaster.client.java.sql.internal.constraint.DbTableConstraint;
 import org.evomaster.core.search.gene.Gene;
 import org.evomaster.core.search.gene.numeric.IntegerGene;
 import org.evomaster.core.sql.SqlAction;
 import org.evomaster.core.sql.SqlInsertBuilder;
 import org.evomaster.core.sql.schema.Column;
+import org.evomaster.core.sql.schema.Table;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.images.builder.ImageFromDockerfile;
@@ -34,6 +36,7 @@ public class DbConstraintSolverZ3InDocker implements DbConstraintSolver {
     private final String tmpFolderPath;
     private final SqlInsertBuilder sqlInsertBuilder;
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DbConstraintSolverZ3InDocker.class.getName());
+    private final DbSchemaDto schemaDto;
 
     /**
      * The current implementation of the Z3 solver reads content either from STDIN or from a file.
@@ -46,6 +49,7 @@ public class DbConstraintSolverZ3InDocker implements DbConstraintSolver {
     public DbConstraintSolverZ3InDocker(DbSchemaDto schemaDto, String resourcesFolder) {
 
         this.tmpFolderPath = resourcesFolder + "tmp/";
+        this.schemaDto = schemaDto;
 
         ImageFromDockerfile image = new ImageFromDockerfile()
                 .withDockerfileFromBuilder(builder -> builder
@@ -96,19 +100,18 @@ public class DbConstraintSolverZ3InDocker implements DbConstraintSolver {
         }
     }
 
-    private List<SqlAction> solveFromTmp(String filename, List<DbTableConstraint> dbTableConstraints) {
+    private List<SqlAction> solveFromTmp(String filename) {
         String model = solveFromFile("tmp/" + filename);
-        return toSqlAction(model, dbTableConstraints);
+        return toSqlAction(model);
     }
 
     /**
      * Given the list of constraints takes the first one and solve the model for that
      *
      * @param model             the string with the model
-     * @param dbTableConstraints
      * @return the Gene with the model
      */
-    private List<SqlAction> toSqlAction(String model, List<DbTableConstraint> dbTableConstraints) {
+    private List<SqlAction> toSqlAction(String model) {
         // Create the insert based on the first constraint
         String[] lines = model.split("\n");
         String[] values = lines[1].substring(2, lines[1].length()-2).split(" ");
@@ -124,7 +127,8 @@ public class DbConstraintSolverZ3InDocker implements DbConstraintSolver {
                 false,
                 false);
 
-        String tableName = dbTableConstraints.get(0).getTableName();
+        // TODO: Handle more than 1 table
+        String tableName = this.schemaDto.tables.get(0).name;
         List<String> history = new LinkedList<>();
         Set<String> columnNames = new HashSet<>(Collections.singletonList("*"));
 
@@ -142,19 +146,21 @@ public class DbConstraintSolverZ3InDocker implements DbConstraintSolver {
      * @return a list of Sql with the necessary inserts according to the constraints
      */
     @Override
-    public List<SqlAction> solve(List<DbTableConstraint> constraintList) {
+    public List<SqlAction> solve() {
         Smt2Writer writer = new Smt2Writer();
 
-        for (DbTableConstraint constraint : constraintList) {
-            boolean succeed = writer.addConstraint(constraint);
-            if (!succeed) {
-                throw new RuntimeException("Constraint not supported: " + constraint);
-            }
+        for (TableDto table : this.schemaDto.tables) {
+            table.tableCheckExpressions.forEach(constraint -> {
+                boolean succeed = writer.addTableCheckExpression(constraint);
+                if (!succeed) {
+                    throw new RuntimeException("Constraint not supported: " + constraint);
+                }
+            });
         }
 
         String fileName = storeToTmpFile(writer);
 
-        List<SqlAction> solution = solveFromTmp(fileName, constraintList);
+        List<SqlAction> solution = solveFromTmp(fileName);
 
         try {
             // TODO: Move this to another thread?

--- a/solver/src/main/java/Smt2Writer.java
+++ b/solver/src/main/java/Smt2Writer.java
@@ -125,10 +125,7 @@ public class Smt2Writer  {
             String expression = checkConstraint.sqlCheckExpression.trim()
                     .replaceAll(" ", "");
 
-            /** TODO: Add support for:
-                - More than one value in the expression
-                - Strings
-             **/
+            // TODO: Add support for expressions of strings and other numeric types
             final Matcher matcher = getCheckMatcher(expression);
 
             this.variables.add(getVariableFromExpression(matcher));

--- a/solver/src/main/java/Smt2Writer.java
+++ b/solver/src/main/java/Smt2Writer.java
@@ -1,3 +1,4 @@
+import org.evomaster.client.java.controller.api.dto.database.schema.TableCheckExpressionDto;
 import org.evomaster.client.java.sql.internal.constraint.DbTableCheckExpression;
 import org.evomaster.client.java.sql.internal.constraint.DbTableConstraint;
 
@@ -19,7 +20,7 @@ import java.util.regex.Pattern;
 public class Smt2Writer  {
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Smt2Writer.class.getName());
-    public static final String CHECK_INT_COMPARE_REGEX = "^CHECK\\(([a-zA-Z_][a-zA-Z0-9_]+)([<|>|=]=?)(.+)\\)$";
+    public static final String CHECK_INT_COMPARE_REGEX = "^\\(\"([a-zA-Z_][a-zA-Z0-9_]+)\"([<|>|=]=?)(.+)\\)$";
 
     // The variables that solve the constraint
     private final List<String> variables = new ArrayList<>();
@@ -27,32 +28,6 @@ public class Smt2Writer  {
     // The assertions that those values need to satisfy
     private final List<String> constraints = new ArrayList<>();
 
-    /**
-     * Tries to parse the constraint from the DBConstraint, if succeeds returns true
-     */
-    public boolean addConstraint(DbTableConstraint constraint) {
-        try {
-            if (constraint instanceof DbTableCheckExpression) {
-                String expression = ((DbTableCheckExpression) constraint)
-                        .getSqlCheckExpression().trim()
-                        .replaceAll(" ", "");
-
-                // TODO: Add support for all other constraints here
-                final Matcher matcher = getCheckMatcher(expression);
-
-                this.variables.add(getVariableFromExpression(matcher));
-                this.constraints.add(getConstraintFromExpressionAsText(matcher));
-
-                return true;
-            }
-            return false;
-        } catch (Exception e) {
-            log.error(
-                    String.format("There was an error parsing the constraint, it may not be a DbTableCheckExpression %s",
-                    e.getMessage()));
-            return false;
-        }
-    }
 
     /**
      * Returns the variable name of the parsed expression in matcher
@@ -145,4 +120,27 @@ public class Smt2Writer  {
         }
     }
 
+    public boolean addTableCheckExpression(TableCheckExpressionDto checkConstraint) {
+        try {
+            String expression = checkConstraint.sqlCheckExpression.trim()
+                    .replaceAll(" ", "");
+
+            /** TODO: Add support for:
+                - More than one value in the expression
+                - Strings
+             **/
+            final Matcher matcher = getCheckMatcher(expression);
+
+            this.variables.add(getVariableFromExpression(matcher));
+            this.constraints.add(getConstraintFromExpressionAsText(matcher));
+
+            return true;
+
+        } catch (Exception e) {
+            log.error(
+                    String.format("There was an error parsing the constraint, it may not be a TableCheckExpressionDto %s",
+                            e.getMessage()));
+            return false;
+        }
+    }
 }

--- a/solver/src/test/java/ConstraintSolverTest.java
+++ b/solver/src/test/java/ConstraintSolverTest.java
@@ -108,10 +108,7 @@ public class ConstraintSolverTest {
 
     @Test
     public void fromConstraintList() {
-        List<DbTableConstraint> constraintList = Collections.singletonList(
-                new DbTableCheckExpression("products", "CHECK (price>100)"));
-
-        List<SqlAction> response = solver.solve(constraintList);
+        List<SqlAction> response = solver.solve();
 
         SqlAction action = response.get(0);
         assertEquals("SQL_Insert_PRODUCTS_PRICE", action.getName());

--- a/solver/src/test/java/Smt2WriterTest.java
+++ b/solver/src/test/java/Smt2WriterTest.java
@@ -1,4 +1,6 @@
+import org.evomaster.client.java.controller.api.dto.database.schema.TableCheckExpressionDto;
 import org.evomaster.client.java.sql.internal.constraint.DbTableCheckExpression;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -11,97 +13,15 @@ public class Smt2WriterTest {
     // ********** CHECK constraint ********** //
     // ************************************** //
     @Test
-    public void productGreaterPrice() {
+    public void productGreaterPriceAsParsed() {
         Smt2Writer writer = new Smt2Writer();
-        boolean succeed = writer.addConstraint(new DbTableCheckExpression("products", "CHECK (price>0)"));
+        boolean succeed = writer.addTableCheckExpression(CheckExpressionFrom("(\"PRICE\" > 100)"));
 
         assertTrue(succeed);
 
         String text = writer.asText();
 
-        assertEquals(expectedSmt2(">", "0"), text);
-    }
-
-    @Test
-    public void productGreaterPriceWithSpaces() {
-        Smt2Writer writer = new Smt2Writer();
-        boolean succeed = writer.addConstraint(new DbTableCheckExpression("products", " CHECK ( price > 0 ) "));
-
-        assertTrue(succeed);
-
-        String text = writer.asText();
-
-        assertEquals(expectedSmt2(">", "0"), text);
-    }
-
-    @Test
-    public void productGreaterPriceWithoutSpaces() {
-        Smt2Writer writer = new Smt2Writer();
-        boolean succeed = writer.addConstraint(new DbTableCheckExpression("products", "CHECK(price>0)"));
-
-        assertTrue(succeed);
-
-        String text = writer.asText();
-
-        assertEquals(expectedSmt2(">", "0"), text);
-    }
-
-    @Test
-    public void productGreaterOrEqualToPrice() {
-        Smt2Writer writer = new Smt2Writer();
-        boolean succeed = writer.addConstraint(new DbTableCheckExpression("products", "CHECK (price>=0)"));
-
-        assertTrue(succeed);
-
-        String text = writer.asText();
-
-        assertEquals(expectedSmt2(">=", "0"), text);
-    }
-
-    @Test
-    public void productLowerPrice() {
-        Smt2Writer writer = new Smt2Writer();
-        boolean succeed = writer.addConstraint(new DbTableCheckExpression("products", "CHECK (price<0)"));
-
-        assertTrue(succeed);
-
-        String text = writer.asText();
-
-        assertEquals(expectedSmt2("<", "0"), text);
-    }
-    @Test
-    public void productLowerOrEqualToPrice() {
-        Smt2Writer writer = new Smt2Writer();
-        boolean succeed = writer.addConstraint(new DbTableCheckExpression("products", "CHECK (price<=0)"));
-
-        assertTrue(succeed);
-
-        String text = writer.asText();
-
-        assertEquals(expectedSmt2("<=", "0"), text);
-    }
-
-    @Test
-    public void productEqualPrice() {
-        Smt2Writer writer = new Smt2Writer();
-        boolean succeed = writer.addConstraint(new DbTableCheckExpression("products", "CHECK (price=0)"));
-
-        assertTrue(succeed);
-
-        String text = writer.asText();
-
-        assertEquals(expectedSmt2("=", "0"), text);
-    }
-    @Test
-    public void productGreaterThanHighPrice() {
-        Smt2Writer writer = new Smt2Writer();
-        boolean succeed = writer.addConstraint(new DbTableCheckExpression("products", "CHECK (price>1000)"));
-
-        assertTrue(succeed);
-
-        String text = writer.asText();
-
-        assertEquals(expectedSmt2(">", "1000"), text);
+        assertEquals(expectedSmt2(">", "100"), text);
     }
 
     // TODO: Add support for multiple check constraints
@@ -109,7 +29,7 @@ public class Smt2WriterTest {
     @Disabled
     public void productGreaterPriceAndStock() {
         Smt2Writer writer = new Smt2Writer();
-        boolean succeed = writer.addConstraint(new DbTableCheckExpression("products", "CHECK (price>1000 AND stock>5)"));
+        boolean succeed = writer.addTableCheckExpression(CheckExpressionFrom("(\"PRICE\">1000 AND \"STOCK\">5)"));
 
         assertTrue(succeed);
 
@@ -127,10 +47,17 @@ public class Smt2WriterTest {
 
     private String expectedSmt2(String cmp, String val) {
         return "(set-logic QF_LIA)\n" +
-                "(declare-const price Int)\n" +
-                "(assert (" + cmp + " price " + val + "))\n" +
+                "(declare-const PRICE Int)\n" +
+                "(assert (" + cmp + " PRICE " + val + "))\n" +
                 "(check-sat)\n" +
-                "(get-value (price))\n";
+                "(get-value (PRICE))\n";
+    }
+
+    @NotNull
+    private TableCheckExpressionDto CheckExpressionFrom(String checkPriceString) {
+        TableCheckExpressionDto checkExpression = new TableCheckExpressionDto();
+        checkExpression.sqlCheckExpression = checkPriceString;
+        return checkExpression;
     }
 
 }


### PR DESCRIPTION
## What does this PR include?
Refactor solver to use the SQL DB schema to parse the constraints instead of sending them as a parameter when invoking the solve method.

As the Check constraints are already parsed as part of the DB Schema then there is no need to parse different string formats from the "CHECK" constraint as it is unified in format.

Added support for more than one variable in check constraint

## Pending work
- Support for string variables in the check constraint
- Support for other numeric genes besides Int
- Support for more than one table 