### PR TITLE
Fix JS & Dotnet minimization

### DIFF
--- a/client-dotnet/src/EvoMaster.Controller/EmbeddedSutController.cs
+++ b/client-dotnet/src/EvoMaster.Controller/EmbeddedSutController.cs
@@ -23,6 +23,10 @@ namespace EvoMaster.Controller {
             ExecutionTracer.SetAction(new Action(dto.Index, dto.InputVariables));
         }
 
+        public override IList<TargetInfo> GetAllCoveredTargetInfos() {
+            return InstrumentationController.GetAllCoveredTargetInfos();
+        }
+
         public override IList<TargetInfo> GetTargetInfos(IEnumerable<int> ids) {
             return InstrumentationController.GetTargetInfos(ids);
         }

--- a/client-dotnet/src/EvoMaster.Controller/SutController.cs
+++ b/client-dotnet/src/EvoMaster.Controller/SutController.cs
@@ -309,6 +309,9 @@ namespace EvoMaster.Controller {
         public abstract string GetDatabaseDriverName();
 
         //TODO: Complete this method
+        public abstract IList<TargetInfo> GetAllCoveredTargetInfos();
+
+        //TODO: Complete this method
         public abstract IList<TargetInfo> GetTargetInfos(IEnumerable<int> ids);
 
         /**

--- a/client-dotnet/src/EvoMaster.Instrumentation/InstrumentationController.cs
+++ b/client-dotnet/src/EvoMaster.Instrumentation/InstrumentationController.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using EvoMaster.Client.Util;
 using EvoMaster.Instrumentation.StaticState;
 
 namespace EvoMaster.Instrumentation {
@@ -23,6 +24,26 @@ namespace EvoMaster.Instrumentation {
                we explicitly say to return ALL targets
              */
             ObjectiveRecorder.ClearFirstTimeEncountered();
+        }
+
+        public static List<TargetInfo> GetAllCoveredTargetInfos() {
+            var list = new List<TargetInfo>();
+
+            var objectives = ExecutionTracer.GetInternalReferenceToObjectiveCoverage();
+            objectives.ToList().ForEach(e => {
+                if (!e.Value.Value.HasValue) { // if value doesn't exist, do nothing
+                    return;
+                }
+                
+                const double tolerance = 1e-9;
+                if (Math.Abs(e.Value.Value.Value - 1d) > tolerance) { // only covered
+                    return;
+                }
+                //try to save bandwidth by only sending mapped ids
+                list.Add(e.Value.EnforceMappedId().WithNoDescriptiveId());
+            });
+
+            return list;
         }
 
         public static List<TargetInfo> GetTargetInfos(IEnumerable<int> ids) {

--- a/client-dotnet/src/EvoMaster.Instrumentation/TargetInfo.cs
+++ b/client-dotnet/src/EvoMaster.Instrumentation/TargetInfo.cs
@@ -1,4 +1,5 @@
 using System;
+using EvoMaster.Instrumentation.StaticState;
 
 namespace EvoMaster.Instrumentation {
     [Serializable]
@@ -34,6 +35,17 @@ namespace EvoMaster.Instrumentation {
                 throw new ArgumentException("Id already existing");
             }
 
+            return new TargetInfo(theId, DescriptiveId, Value, ActionIndex);
+        }
+
+        public TargetInfo EnforceMappedId(){
+            if(DescriptiveId == null){
+                throw new InvalidOperationException("Cannot enforce mapped id from records in which the descriptive id was removed");
+            }
+            if(MappedId != null){
+                return this;
+            }
+            var theId = ObjectiveRecorder.GetMappedId(DescriptiveId);
             return new TargetInfo(theId, DescriptiveId, Value, ActionIndex);
         }
 

--- a/client-js/evomaster-client-js/src/controller/EMController.ts
+++ b/client-js/evomaster-client-js/src/controller/EMController.ts
@@ -211,18 +211,29 @@ export default class EMController {
         this.app.get(c.BASE_PATH + c.TEST_RESULTS, (req, res) => {
 
             const idsParam = (req.query.ids) as string;
+            const allCovered = (req.query.allCovered) as boolean;
 
-            const ids = new Set(idsParam
-                .split(",")
-                .filter((s) => s && s.trim().length > 0)
-                .map((s) => parseInt(s, 10))
-            );
+            let targetInfos
+            if (!allCovered) {
+                const ids = new Set(idsParam
+                    .split(",")
+                    .filter((s) => s && s.trim().length > 0)
+                    .map((s) => parseInt(s, 10))
+                );
 
-            const targetInfos = this.sutController.getTargetInfos(ids);
-            if (!targetInfos) {
-                res.status(500);
-                res.json(WrappedResponseDto.withError("Failed to collect target information for " + ids.size + " ids"));
-                return;
+                targetInfos = this.sutController.getTargetInfos(ids);
+                if (!targetInfos) {
+                    res.status(500);
+                    res.json(WrappedResponseDto.withError("Failed to collect target information for " + ids.size + " ids"));
+                    return;
+                }
+            } else {
+                targetInfos = this.sutController.getAllCoveredTargetInfos();
+                if (!targetInfos) {
+                    res.status(500);
+                    res.json(WrappedResponseDto.withError("Failed to collect all covered target information"));
+                    return;
+                }
             }
 
             const dto = new TestResultsDto();

--- a/client-js/evomaster-client-js/src/controller/SutController.ts
+++ b/client-js/evomaster-client-js/src/controller/SutController.ts
@@ -117,6 +117,23 @@ export default abstract class SutController implements SutHandler {
         ObjectiveRecorder.clearFirstTimeEncountered();
     }
 
+    public getAllCoveredTargetInfos(): Array<TargetInfo> {
+
+        const list = new Array<TargetInfo>();
+
+        const objectives = ExecutionTracer.getInternalReferenceToObjectiveCoverage();
+
+        objectives.forEach((info, descriptiveId, map) => {
+            if (info.value != 1.0) { // only covered
+                return
+            }
+            //try to save bandwidth by only sending mapped ids
+            list.push(info.enforceMappedId().withNoDescriptiveId());
+        });
+
+        return list;
+    }
+
     public getTargetInfos(ids: Set<number>): Array<TargetInfo> {
 
         const list = new Array<TargetInfo>();

--- a/client-js/evomaster-client-js/src/instrumentation/TargetInfo.ts
+++ b/client-js/evomaster-client-js/src/instrumentation/TargetInfo.ts
@@ -1,3 +1,5 @@
+import ObjectiveRecorder from "./staticstate/ObjectiveRecorder";
+
 /**
  * This represents the same data as in TargetInfoDto.
  * Here is replicated to have a clear distinction on how
@@ -41,5 +43,16 @@ export default class TargetInfo {
 
     public withNoDescriptiveId(): TargetInfo {
         return new TargetInfo(this.mappedId, null, this.value, this.actionIndex);
+    }
+
+    public enforceMappedId(): TargetInfo {
+        if(this.descriptiveId == null){
+            throw new Error("Cannot enforce mapped id from records in which the descriptive id was removed");
+        }
+        if(this.mappedId != null){
+            return this;
+        }
+        let theID = ObjectiveRecorder.getMappedId(this.descriptiveId);
+        return new TargetInfo(theID, this.descriptiveId, this.value, this.actionIndex);
     }
 }


### PR DESCRIPTION
While working in a driver and comparing it with different test SUTs I found that JS and Dotnet were having a big difference on line coverage when comparing it with Java solution. (from expected ~95% to ~55% of line coverage in NCS)

A bit more of debugging made me realize that the issue was when using the param minimization=true.

After a bit of more debugging I found that there was added in 2.0.0 (if I am not mistaken) a new param in the testResults endpoint called `allCovered` that was being ignored in both controllers.

I added this new param in both of them and from my testings in NCS looks like everything is working as intended now hitting the expected line coverage with both drivers.