### PR TITLE
Python imports and init tests

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/output/service/TestCaseWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/service/TestCaseWriter.kt
@@ -95,6 +95,7 @@ abstract class TestCaseWriter {
             format.isKotlin() -> lines.add("fun ${test.name}()  {")
             format.isJavaScript() -> lines.add("test(\"${test.name}\", async () => {")
             format.isCsharp() -> lines.add("public async Task ${test.name}() {")
+            format.isPython() -> lines.add("def ${test.name}(self):")
         }
 
 
@@ -103,6 +104,9 @@ abstract class TestCaseWriter {
             val insertionVars = mutableListOf<Pair<String, String>>()
             // FIXME: HostnameResolutionActions can be a separately, for now it's under
             //  handleFieldDeclarations.
+            if (format.isPython()) {
+                lines.add("pass")
+            }
             handleFieldDeclarations(lines, baseUrlOfSut, ind, insertionVars)
             handleActionCalls(lines, baseUrlOfSut, ind, insertionVars, testCaseName = test.name, testSuitePath)
         }

--- a/core/src/main/kotlin/org/evomaster/core/output/service/TestCaseWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/service/TestCaseWriter.kt
@@ -104,7 +104,7 @@ abstract class TestCaseWriter {
             val insertionVars = mutableListOf<Pair<String, String>>()
             // FIXME: HostnameResolutionActions can be a separately, for now it's under
             //  handleFieldDeclarations.
-            if (format.isPython()) {
+            if (format.isPython()) { // TODO PhG: remove this when python test content is added
                 lines.add("pass")
             }
             handleFieldDeclarations(lines, baseUrlOfSut, ind, insertionVars)

--- a/core/src/main/kotlin/org/evomaster/core/output/service/TestSuiteWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/service/TestSuiteWriter.kt
@@ -476,7 +476,6 @@ class TestSuiteWriter {
             lines.add("import json")
             lines.add("import unittest")
             lines.add("import requests")
-            createRequirementsTxt("requests==2.25.1")
         }
 
         when {
@@ -500,16 +499,6 @@ class TestSuiteWriter {
             defineClass(name, lines)
             lines.addEmpty()
         }
-    }
-
-    private fun createRequirementsTxt(testFileContent: String) {
-        val path = Paths.get(config.outputFolder, "requirements.txt")
-
-        Files.createDirectories(path.parent)
-        Files.deleteIfExists(path)
-        Files.createFile(path)
-
-        path.toFile().appendText(testFileContent)
     }
 
     private fun classFields(lines: Lines, format: OutputFormat) {

--- a/core/src/main/kotlin/org/evomaster/core/output/service/TestSuiteWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/service/TestSuiteWriter.kt
@@ -935,6 +935,12 @@ class TestSuiteWriter {
             lines.addEmpty(2)
             lines.add("}")
         }
+
+        if (config.outputFormat.isPython()) {
+            lines.add("if __name__ == '__main__':")
+            lines.indent()
+            lines.add("unittest.main()")
+        }
     }
 
     private fun defineClass(name: TestSuiteFileName, lines: Lines) {

--- a/core/src/main/kotlin/org/evomaster/core/output/service/TestSuiteWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/service/TestSuiteWriter.kt
@@ -472,7 +472,17 @@ class TestSuiteWriter {
             addUsing("EvoMaster.Controller", lines)
         }
 
-        lines.addEmpty(4)
+        if (format.isPython()) {
+            lines.add("import json")
+            lines.add("import unittest")
+            lines.add("import requests")
+            createRequirementsTxt("requests==2.25.1")
+        }
+
+        when {
+            format.isPython() -> lines.addEmpty(2)
+            else -> lines.addEmpty(4)
+        }
 
         classDescriptionComment(solution, lines, timestamp)
 
@@ -490,6 +500,16 @@ class TestSuiteWriter {
             defineClass(name, lines)
             lines.addEmpty()
         }
+    }
+
+    private fun createRequirementsTxt(testFileContent: String) {
+        val path = Paths.get(config.outputFolder, "requirements.txt")
+
+        Files.createDirectories(path.parent)
+        Files.deleteIfExists(path)
+        Files.createFile(path)
+
+        path.toFile().appendText(testFileContent)
     }
 
     private fun classFields(lines: Lines, format: OutputFormat) {

--- a/core/src/main/kotlin/org/evomaster/core/output/service/TestSuiteWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/service/TestSuiteWriter.kt
@@ -496,7 +496,7 @@ class TestSuiteWriter {
             defineFixture(lines, controllerName)
         }
 
-        if (format.isJavaOrKotlin() || format.isCsharp()) {
+        if (format.isJavaOrKotlin() || format.isCsharp() || format.isPython()) {
             defineClass(name, lines)
             lines.addEmpty()
         }
@@ -949,10 +949,11 @@ class TestSuiteWriter {
             format.isCsharp() -> lines.append("public ")
         }
 
-        if (!format.isCsharp())
-            lines.append("class ${name.getClassName()} {")
-        else
-            lines.append("class ${name.getClassName()} : IClassFixture<$fixtureClass> {")
+        when {
+            format.isCsharp() -> lines.append("class ${name.getClassName()} : IClassFixture<$fixtureClass> {")
+            format.isPython() -> lines.append("class ${name.getClassName()}(unittest.TestCase):")
+            else -> lines.append("class ${name.getClassName()} {")
+        }
     }
 
     private fun addImport(klass: String, lines: Lines, static: Boolean = false) {

--- a/core/src/test/kotlin/org/evomaster/core/output/service/TestSuiteWriterTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/output/service/TestSuiteWriterTest.kt
@@ -53,7 +53,14 @@ class TestSuiteWriterTest{
         config.outputFilePrefix = "Foo_testEmptySuite"
         config.outputFileSuffix = ""
 
-        val solution = getEmptySolution(config)
+        val solution = Solution<RestIndividual>(
+            mutableListOf(),
+            config.outputFilePrefix,
+            config.outputFileSuffix,
+            Termination.NONE,
+            listOf(),
+            listOf()
+        )
 
 
         //make sure we delete any existing folder from previous test runs
@@ -97,50 +104,6 @@ class TestSuiteWriterTest{
         assertTrue(methods.any { it.name == "initClass" })
         assertTrue(methods.any { it.name == "tearDown" })
         assertTrue(methods.any { it.name == "initTest" })
-    }
-
-
-    @Test
-    fun testPythonCreatesRequirementsFile(){
-
-        val injector = LifecycleInjector.builder()
-            .withModules(BaseModule(), ReducedModule())
-            .build().createInjector()
-
-        val config = injector.getInstance(EMConfig::class.java)
-        config.createTests = true
-        config.outputFormat = OutputFormat.PYTHON_UNITTEST
-        config.outputFolder = "$baseTargetFolder/python_requirements"
-        config.outputFilePrefix = "Foo_testPythonRequirements"
-        config.outputFileSuffix = ""
-
-        val solution = getEmptySolution(config)
-
-        //make sure we delete any existing folder from previous test runs
-        val srcFolder = File(config.outputFolder)
-        srcFolder.deleteRecursively()
-
-        val writer = injector.getInstance(TestSuiteWriter::class.java)
-        //write the test suite
-        writer.writeTests(solution, FakeController::class.qualifiedName!!, null)
-
-        // the requirements file should exist
-        val requirementsFile = Paths.get("${config.outputFolder}/requirements.txt")
-        assertTrue(Files.exists(requirementsFile))
-
-        val testContent = String(Files.readAllBytes(requirementsFile))
-        assertTrue(testContent.contains("requests==2.25.1"))
-    }
-
-    private fun getEmptySolution(config: EMConfig): Solution<RestIndividual> {
-        return Solution<RestIndividual>(
-            mutableListOf(),
-            config.outputFilePrefix,
-            config.outputFileSuffix,
-            Termination.NONE,
-            listOf(),
-            listOf()
-        )
     }
 
 }


### PR DESCRIPTION
# What

- Python test classes now contain the class name and imports.
- Test cases are created empty with the `pass` directive. This will be removed in the next PR when python tests are able to actually perform requests and assertions
- main footer added so as to be able to directly execute tests directly calling for example `python3 EvoMaster_successes_Test.py`