### PR TITLE
MonotonicGA & Lifecycle Hooks

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/search/algorithms/AbstractGeneticAlgorithm.kt
+++ b/core/src/main/kotlin/org/evomaster/core/search/algorithms/AbstractGeneticAlgorithm.kt
@@ -57,6 +57,28 @@ abstract class AbstractGeneticAlgorithm<T> : SearchAlgorithm<T>() where T : Indi
         observers.remove(observer)
     }
 
+    /** Call at the start of each searchOnce to begin a new generation scope. */
+    protected fun beginGeneration() {
+        observers.forEach { it.onGenerationStart() }
+    }
+
+    /** Call at the end of each searchOnce to report generation aggregates. */
+    protected fun endGeneration() {
+        val snapshot = population.toList()
+        val bestScore = snapshot.maxOfOrNull { score(it) } ?: 0.0
+        observers.forEach { it.onGenerationEnd(snapshot, bestScore) }
+    }
+
+    /** Start a new step inside current iteration. */
+    protected fun beginStep() {
+        observers.forEach { it.onStepStart() }
+    }
+
+    /** End current step and report aggregates. */
+    protected fun endStep() {
+        observers.forEach { it.onStepEnd() }
+    }
+
     /**
      * Called once before the search begins. Clears any old population and initializes a new one.
      */
@@ -184,12 +206,9 @@ abstract class AbstractGeneticAlgorithm<T> : SearchAlgorithm<T>() where T : Indi
     /**
      * Combined fitness of a suite computed only over [frozenTargets] when set; otherwise full combined fitness.
      */
-    protected fun score(w: WtsEvalIndividual<T>): Double {
-        if (w.suite.isEmpty()) return 0.0
-
-        // Explicitly use full combined fitness when solution source is POPULATION
-        if (config.gaSolutionSource == EMConfig.GASolutionSource.POPULATION) {
-            return w.calculateCombinedFitness()
+    public fun score(w: WtsEvalIndividual<T>): Double {
+        if (w.suite.isEmpty()) {
+            return 0.0
         }
 
         if (frozenTargets.isEmpty()) {
@@ -202,7 +221,9 @@ abstract class AbstractGeneticAlgorithm<T> : SearchAlgorithm<T>() where T : Indi
         var sum = 0.0
         frozenTargets.forEach { t ->
             val comp = view[t]
-            if (comp != null) sum += comp.score
+            if (comp != null){
+                sum += comp.score
+            }
         }
         return sum
     }

--- a/core/src/main/kotlin/org/evomaster/core/search/algorithms/MonotonicGeneticAlgorithm.kt
+++ b/core/src/main/kotlin/org/evomaster/core/search/algorithms/MonotonicGeneticAlgorithm.kt
@@ -16,10 +16,12 @@ import kotlin.math.max
  * This is a more conservative variant compared to standard GAs, aiming to preserve
  * the quality of solutions across generations and avoid degradation in performance.
  *
- * This class builds on top of [StandardGeneticAlgorithm] but overrides
- * population update logic to enforce the monotonic condition.
+ * This class relies on the common GA utilities provided by
+ * [AbstractGeneticAlgorithm] (selection, crossover, mutation, population
+ * management), and overrides the generation update logic to enforce the
+ * monotonic condition.
  */
-class MonotonicGeneticAlgorithm<T> : StandardGeneticAlgorithm<T>() where T : Individual {
+class MonotonicGeneticAlgorithm<T> : AbstractGeneticAlgorithm<T>() where T : Individual {
 
     override fun getType(): EMConfig.Algorithm {
         return EMConfig.Algorithm.MonotonicGA
@@ -47,11 +49,16 @@ class MonotonicGeneticAlgorithm<T> : StandardGeneticAlgorithm<T>() where T : Ind
      * or the time budget is exhausted.
      */
     override fun searchOnce() {
+        beginGeneration()
+        // Freeze objectives for this generation
+        frozenTargets = archive.notCoveredTargets()
         val n = config.populationSize
 
-        val nextPop: MutableList<WtsEvalIndividual<T>> = mutableListOf()
+        // Start next population with elites (elitism)
+        val nextPop: MutableList<WtsEvalIndividual<T>> = formTheNextPopulation(population)
 
         while (nextPop.size < n) {
+            beginStep()
             val p1 = tournamentSelection()
             val p2 = tournamentSelection()
 
@@ -74,10 +81,9 @@ class MonotonicGeneticAlgorithm<T> : StandardGeneticAlgorithm<T>() where T : Ind
 
             // Monotonic replacement rule:
             // Keep offspring only if they're better than the parents
-            if (max(o1.calculateCombinedFitness(), o2.calculateCombinedFitness()) >
-                max(p1.calculateCombinedFitness(), p2.calculateCombinedFitness())
+            if (max(score(o1), score(o2)) >
+                max(score(p1), score(p2))
             ) {
-                
                 nextPop.add(o1)
                 nextPop.add(o2)
             } else {
@@ -86,12 +92,15 @@ class MonotonicGeneticAlgorithm<T> : StandardGeneticAlgorithm<T>() where T : Ind
             }
 
             if (!time.shouldContinueSearch()) {
+                endStep()
                 break
             }
+            endStep()
         }
 
         // Replace the current population with the newly formed one
         population.clear()
         population.addAll(nextPop)
+        endGeneration()
     }
 }

--- a/core/src/main/kotlin/org/evomaster/core/search/algorithms/StandardGeneticAlgorithm.kt
+++ b/core/src/main/kotlin/org/evomaster/core/search/algorithms/StandardGeneticAlgorithm.kt
@@ -42,6 +42,7 @@ open class StandardGeneticAlgorithm<T> : AbstractGeneticAlgorithm<T>() where T :
      * Terminates early if the time budget is exceeded.
      */
     override fun searchOnce() {
+        beginGeneration()
         // Freeze objectives for this generation
         frozenTargets = archive.notCoveredTargets()
         val n = config.populationSize
@@ -50,6 +51,7 @@ open class StandardGeneticAlgorithm<T> : AbstractGeneticAlgorithm<T>() where T :
         val nextPop = formTheNextPopulation(population)
 
         while (nextPop.size < n) {
+            beginStep()
             val sizeBefore = nextPop.size
 
             // Select two parents
@@ -78,12 +80,15 @@ open class StandardGeneticAlgorithm<T> : AbstractGeneticAlgorithm<T>() where T :
 
             // Stop early if time budget is exhausted
             if (!time.shouldContinueSearch()) {
+                endStep()
                 break
             }
+            endStep()
         }
 
         // Replace current population with the new one
         population.clear()
         population.addAll(nextPop)
+        endGeneration()
     }
 }

--- a/core/src/main/kotlin/org/evomaster/core/search/algorithms/observer/GAObserver.kt
+++ b/core/src/main/kotlin/org/evomaster/core/search/algorithms/observer/GAObserver.kt
@@ -8,6 +8,12 @@ import org.evomaster.core.search.algorithms.wts.WtsEvalIndividual
  * Default methods are no-ops so listeners can implement only what they need.
  */
 interface GAObserver<T : Individual> {
+    /** Called at the start of a generation (one call to searchOnce). */
+    fun onGenerationStart() {}
+
+    /** Called at the start of a step inside a generation. */
+    fun onStepStart() {}
+
     /** Called when one parent is selected. */
     fun onSelection(sel: WtsEvalIndividual<T>) {}
     /** Called immediately after crossover is applied to [x] and [y]. */
@@ -15,6 +21,17 @@ interface GAObserver<T : Individual> {
 
     /** Called immediately after mutation is applied to [wts]. */
     fun onMutation(wts: WtsEvalIndividual<T>) {}
+
+    /**
+     * Called at the end of a generation (one call to searchOnce), with a snapshot of the final population
+     * and the best score according to the GA's internal scoring (e.g., frozen targets).
+     */
+    fun onGenerationEnd(population: List<WtsEvalIndividual<T>>, bestScore: Double) {}
+
+    /**
+     * Called at the end of a step inside a generation.
+     */
+    fun onStepEnd() {}
 }
 
 

--- a/core/src/test/kotlin/org/evomaster/core/search/algorithms/MonotonicGeneticAlgorithmTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/search/algorithms/MonotonicGeneticAlgorithmTest.kt
@@ -1,0 +1,264 @@
+package org.evomaster.core.search.algorithms
+
+import com.google.inject.Injector
+import com.google.inject.Key
+import com.google.inject.Module
+import com.google.inject.TypeLiteral
+import com.netflix.governator.guice.LifecycleInjector
+import org.evomaster.core.BaseModule
+import org.evomaster.core.EMConfig
+import org.evomaster.core.TestUtils
+import org.evomaster.core.search.algorithms.observer.GARecorder
+import org.evomaster.core.search.algorithms.onemax.OneMaxIndividual
+import org.evomaster.core.search.algorithms.onemax.OneMaxModule
+import org.evomaster.core.search.algorithms.onemax.OneMaxSampler
+import org.evomaster.core.search.algorithms.strategy.FixedSelectionStrategy
+import org.evomaster.core.search.service.ExecutionPhaseController
+import org.evomaster.core.search.service.Randomness
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.BeforeEach
+
+class MonotonicGeneticAlgorithmTest {
+
+    private lateinit var injector: Injector
+
+    @BeforeEach
+    fun setUp() {
+        injector = LifecycleInjector.builder()
+            .withModules(* arrayOf<Module>(OneMaxModule(), BaseModule()))
+            .build().createInjector()
+    }
+
+    // Verifies that the Monotonic GA can find the optimal solution for the OneMax problem
+    @Test
+    fun testMonotonicGeneticAlgorithmFindsOptimum() {
+        TestUtils.handleFlaky {
+            val monoGA = injector.getInstance(
+                Key.get(
+                    object : TypeLiteral<MonotonicGeneticAlgorithm<OneMaxIndividual>>() {})
+            )
+
+            val config = injector.getInstance(EMConfig::class.java)
+            config.maxEvaluations = 10000
+            config.stoppingCriterion = EMConfig.StoppingCriterion.ACTION_EVALUATIONS
+
+            val epc = injector.getInstance(ExecutionPhaseController::class.java)
+            epc.startSearch()
+            val solution = monoGA.search()
+            epc.finishSearch()
+            assertTrue(solution.individuals.size == 1)
+            assertEquals(OneMaxSampler.DEFAULT_N.toDouble(), solution.overall.computeFitnessScore(), 0.001)
+        }
+    }
+
+    
+    // Tests Edge Case: CrossoverProbability=0 on Monotonic GA
+    @Test
+    fun testNoCrossoverWhenProbabilityZero_Monotonic() {
+        TestUtils.handleFlaky {
+            val fixedSel = FixedSelectionStrategy()
+            val (ga, localInjector) = createMonotonicGAWithSelection(fixedSel)
+
+            val rec = GARecorder<OneMaxIndividual>()
+            ga.addObserver(rec)
+
+            val config = localInjector.getInstance(EMConfig::class.java)
+            localInjector.getInstance(Randomness::class.java).updateSeed(42)
+
+            config.populationSize = 4
+            config.elitesCount = 2
+            config.xoverProbability = 0.0 // disable crossover
+            config.fixedRateMutation = 1.0 // force mutation
+            config.gaSolutionSource = EMConfig.GASolutionSource.POPULATION
+            config.maxEvaluations = 100_000
+            config.stoppingCriterion = EMConfig.StoppingCriterion.ACTION_EVALUATIONS
+
+            ga.setupBeforeSearch()
+
+            val pop = ga.getViewOfPopulation()
+            val expectedElites = pop.sortedByDescending { it.calculateCombinedFitness() }.take(2)
+            val expectedNonElites = pop.filter { it !in expectedElites }
+
+            fixedSel.setOrder(listOf(expectedNonElites[0], expectedNonElites[1]))
+
+            ga.searchOnce()
+
+            val nextPop = ga.getViewOfPopulation()
+
+            assertEquals(config.populationSize, nextPop.size)
+            assertEquals(2, rec.selections.size)
+            assertTrue(nextPop.any { it === expectedElites[0] })
+            assertTrue(nextPop.any { it === expectedElites[1] })
+
+            // crossover disabled
+            assertEquals(0, rec.xoCalls.size)
+            // mutation still applied twice
+            assertEquals(2, rec.mutated.size)
+        }
+    }
+    
+    // Tests Edge Case: MutationProbability=0 on Monotonic GA
+    @Test
+    fun testNoMutationWhenProbabilityZero_Monotonic() {
+        TestUtils.handleFlaky {
+            val fixedSel = FixedSelectionStrategy()
+            val (ga, localInjector) = createMonotonicGAWithSelection(fixedSel)
+
+            val rec = GARecorder<OneMaxIndividual>()
+            ga.addObserver(rec)
+
+            val config = localInjector.getInstance(EMConfig::class.java)
+            localInjector.getInstance(Randomness::class.java).updateSeed(42)
+
+            config.populationSize = 4
+            config.elitesCount = 2
+            config.xoverProbability = 1.0 // force crossover
+            config.fixedRateMutation = 0.0 // disable mutation
+            config.gaSolutionSource = EMConfig.GASolutionSource.POPULATION
+            config.maxEvaluations = 100_000
+            config.stoppingCriterion = EMConfig.StoppingCriterion.ACTION_EVALUATIONS
+            
+            ga.setupBeforeSearch()
+
+            val pop = ga.getViewOfPopulation()
+            val expectedElites = pop.sortedByDescending { it.calculateCombinedFitness() }.take(2)
+            val expectedNonElites = pop.filter { it !in expectedElites }
+
+            fixedSel.setOrder(listOf(expectedNonElites[0], expectedNonElites[1]))
+
+            ga.searchOnce()
+
+            val nextPop = ga.getViewOfPopulation()
+
+            assertEquals(config.populationSize, nextPop.size)
+            assertEquals(2, rec.selections.size)
+            assertTrue(nextPop.any { it === expectedElites[0] })
+            assertTrue(nextPop.any { it === expectedElites[1] })
+
+            // crossover forced
+            assertEquals(1, rec.xoCalls.size)
+            // mutation disabled
+            assertEquals(0, rec.mutated.size)           
+        }
+    }
+    // Verifies that one generation is formed by elites plus monotonic replacement outcome
+    @Test
+    fun testNextGenerationElitesPlusMonotonicReplacement() {
+        TestUtils.handleFlaky {
+            // Fixed selection for determinism
+            val fixedSel = FixedSelectionStrategy()
+            val (ga, localInjector) = createMonotonicGAWithSelection(fixedSel)
+
+            val rec = GARecorder<OneMaxIndividual>()
+            ga.addObserver(rec)
+
+            val config = localInjector.getInstance(EMConfig::class.java)
+            localInjector.getInstance(Randomness::class.java).updateSeed(42)
+
+            config.populationSize = 4
+            config.elitesCount = 2
+            config.xoverProbability = 1.0
+            config.fixedRateMutation = 1.0
+            config.gaSolutionSource = EMConfig.GASolutionSource.POPULATION
+            config.maxEvaluations = 100_000
+            config.stoppingCriterion = EMConfig.StoppingCriterion.ACTION_EVALUATIONS
+            
+            ga.setupBeforeSearch()
+
+            val pop = ga.getViewOfPopulation()
+
+            // Elites by combined fitness
+            val expectedElites = pop.sortedByDescending { it.calculateCombinedFitness() }.take(2)
+            val expectedNonElites = pop.filter { it !in expectedElites }
+
+            // Force selection of non-elites
+            val p1 = expectedNonElites[0]
+            val p2 = expectedNonElites[1]
+            fixedSel.setOrder(listOf(p1, p2))
+
+            ga.searchOnce()
+
+            val nextPop = ga.getViewOfPopulation()
+
+            // Size preserved
+            assertEquals(config.populationSize, nextPop.size)
+            // Elites carried over
+            assertTrue(nextPop.any { it === expectedElites[0] })
+            assertTrue(nextPop.any { it === expectedElites[1] })
+            // Selections counted via observer
+            assertEquals(2, rec.selections.size)
+
+            // Offspring seen via crossover observer
+            assertEquals(1, rec.xoCalls.size)
+            val (o1, o2) = rec.xoCalls[0]
+
+            // Monotonic rule: keep offspring only if better than parents according to GA score
+            val parentBest = kotlin.math.max(ga.score(p1), ga.score(p2))
+            val childBest = kotlin.math.max(ga.score(o1), ga.score(o2))
+
+            if (childBest > parentBest) {
+                assertTrue(nextPop.any { it === o1 })
+                assertTrue(nextPop.any { it === o2 })
+                assertFalse(nextPop.containsAll(listOf(p1, p2)))
+            } else {
+                assertTrue(nextPop.any { it === p1 })
+                assertTrue(nextPop.any { it === p2 })
+                assertFalse(nextPop.containsAll(listOf(o1, o2)))
+            }
+
+            // Mutation applied twice to offspring
+            assertEquals(2, rec.mutated.size)
+            assertTrue(rec.mutated.any { it === o1 })
+            assertTrue(rec.mutated.any { it === o2 })
+        }
+    }
+    
+    // Ensures that maximum fitness never decreases across generations when running full search
+    @Test
+    fun testMonotonicReplacementRule() {
+        TestUtils.handleFlaky {
+            val monoGA = injector.getInstance(
+                Key.get(
+                    object : TypeLiteral<MonotonicGeneticAlgorithm<OneMaxIndividual>>() {})
+            )
+
+            val rec = GARecorder<OneMaxIndividual>()
+            monoGA.addObserver(rec)
+
+            val config = injector.getInstance(EMConfig::class.java)
+            config.maxEvaluations = 100
+            config.elitesCount = 4
+            config.stoppingCriterion = EMConfig.StoppingCriterion.ACTION_EVALUATIONS
+
+            val epc = injector.getInstance(ExecutionPhaseController::class.java)
+            epc.startSearch()
+            val solution = monoGA.search()
+            epc.finishSearch()
+            // Check monotonicity across recorded generations: best score (selection metric) is non-decreasing
+            val bestScores = rec.bestFitnessPerGeneration
+            for (k in 1 until bestScores.size) {
+                assertTrue(bestScores[k] >= bestScores[k-1])
+            }
+        }
+    }
+}
+
+// --- Test helpers ---
+
+private fun createMonotonicGAWithSelection(
+    fixedSel: FixedSelectionStrategy
+): Pair<MonotonicGeneticAlgorithm<OneMaxIndividual>, Injector> {
+    val injector = LifecycleInjector.builder()
+        .withModules(* arrayOf<Module>(OneMaxModule(), BaseModule()))
+        .build().createInjector()
+
+    val ga = injector.getInstance(
+        Key.get(object : TypeLiteral<MonotonicGeneticAlgorithm<OneMaxIndividual>>() {})
+    )
+    // Override selection strategy directly on the GA instance (no DI here)
+    ga.useSelectionStrategy(fixedSel)
+    return ga to injector
+}
+
+

--- a/core/src/test/kotlin/org/evomaster/core/search/algorithms/observer/GARecorder.kt
+++ b/core/src/test/kotlin/org/evomaster/core/search/algorithms/observer/GARecorder.kt
@@ -8,6 +8,7 @@ class GARecorder<T : Individual> : GAObserver<T> {
     val selections = mutableListOf<WtsEvalIndividual<T>>()
     val xoCalls = mutableListOf<Pair<WtsEvalIndividual<T>, WtsEvalIndividual<T>>>()
     val mutated = mutableListOf<WtsEvalIndividual<T>>()
+    val bestFitnessPerGeneration = mutableListOf<Double>()
 
     override fun onSelection(sel: WtsEvalIndividual<T>) {
         selections.add(sel)
@@ -19,6 +20,10 @@ class GARecorder<T : Individual> : GAObserver<T> {
 
     override fun onMutation(wts: WtsEvalIndividual<T>) {
         mutated.add(wts)
+    }
+
+    override fun onGenerationEnd(population: List<WtsEvalIndividual<T>>, bestScore: Double) {
+        bestFitnessPerGeneration.add(bestScore)
     }
 }
 


### PR DESCRIPTION
## PR Summary

We implemented changes to AbstractGeneticAlgorithm` and `MonotonicGeneticAlgorithm`:

- **Lifecycle hooks**: generation/step observer callbacks to trace GA execution.
- **Monotonic GA**: enforces pair-wise monotonic replacement and starts each generation from elites.

---

## Main Changes

- **Base GA (`AbstractGeneticAlgorithm`)**:
  - Added lifecycle methods: `beginGeneration`, `endGeneration`, `beginStep`, `endStep`.
  - Observer API: `onGenerationStart`, `onStepStart`,  `onStepEnd`, `onGenerationEnd(population, bestScore)`.
  - **`score` function**: now **always** uses `frozenTargets` when present; falls back to combined fitness if empty.
- **`MonotonicGeneticAlgorithm`**:
  - Starts next population with elites (`formTheNextPopulation`).
  - Uses the same lifecycle hooks as the base GA.
- **GA Recorder/Observer**:
  - Introduces observer hooks to record lifecycle and operator metrics.
  - Records `bestFitnessPerGeneration` using the emitted `bestScore` (max `score` of the generation).

## Tests

- Monotonic GA tests added:
  - Elites + Monotonic replacement (pairwise strict improvement using `score`).
  - Edge cases: `xoverProbability = 0` (no crossovers) and `fixedRateMutation = 0` (no mutations).
  - Monotonicity across generations: assert non‑decreasing `bestFitnessPerGeneration` (generation `score`).