### PR TITLE
Assert DTOs are correctly generated by using reflection

### DIFF
--- a/core-tests/e2e-tests/spring-rest-openapi-v3/src/main/kotlin/com/foo/rest/examples/spring/openapi/v3/dtoreflectiveassert/AllOfDto.kt
+++ b/core-tests/e2e-tests/spring-rest-openapi-v3/src/main/kotlin/com/foo/rest/examples/spring/openapi/v3/dtoreflectiveassert/AllOfDto.kt
@@ -1,0 +1,8 @@
+package com.foo.rest.examples.spring.openapi.v3.dtoreflectiveassert
+
+class AllOfDto {
+
+    var name: String = ""
+    var age: Int = -1
+
+}

--- a/core-tests/e2e-tests/spring-rest-openapi-v3/src/main/kotlin/com/foo/rest/examples/spring/openapi/v3/dtoreflectiveassert/AnyOfDto.kt
+++ b/core-tests/e2e-tests/spring-rest-openapi-v3/src/main/kotlin/com/foo/rest/examples/spring/openapi/v3/dtoreflectiveassert/AnyOfDto.kt
@@ -1,0 +1,8 @@
+package com.foo.rest.examples.spring.openapi.v3.dtoreflectiveassert
+
+class AnyOfDto {
+
+    var email: String = ""
+    var phone: String = ""
+
+}

--- a/core-tests/e2e-tests/spring-rest-openapi-v3/src/main/kotlin/com/foo/rest/examples/spring/openapi/v3/dtoreflectiveassert/ChildSchemaDto.kt
+++ b/core-tests/e2e-tests/spring-rest-openapi-v3/src/main/kotlin/com/foo/rest/examples/spring/openapi/v3/dtoreflectiveassert/ChildSchemaDto.kt
@@ -1,0 +1,8 @@
+package com.foo.rest.examples.spring.openapi.v3.dtoreflectiveassert
+
+class ChildSchemaDto {
+
+    var name: String = ""
+    var age: Int = -1
+
+}

--- a/core-tests/e2e-tests/spring-rest-openapi-v3/src/main/kotlin/com/foo/rest/examples/spring/openapi/v3/dtoreflectiveassert/DtoReflectiveAssertApplication.kt
+++ b/core-tests/e2e-tests/spring-rest-openapi-v3/src/main/kotlin/com/foo/rest/examples/spring/openapi/v3/dtoreflectiveassert/DtoReflectiveAssertApplication.kt
@@ -1,0 +1,17 @@
+package com.foo.rest.examples.spring.openapi.v3.dtoreflectiveassert
+
+import org.springframework.boot.SpringApplication
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+
+@SpringBootApplication(exclude = [SecurityAutoConfiguration::class])
+open class DtoReflectiveAssertApplication {
+
+    companion object {
+        @JvmStatic
+        fun main(args: Array<String>) {
+            SpringApplication.run(DtoReflectiveAssertApplication::class.java, *args)
+        }
+    }
+
+}

--- a/core-tests/e2e-tests/spring-rest-openapi-v3/src/main/kotlin/com/foo/rest/examples/spring/openapi/v3/dtoreflectiveassert/DtoReflectiveAssertRest.kt
+++ b/core-tests/e2e-tests/spring-rest-openapi-v3/src/main/kotlin/com/foo/rest/examples/spring/openapi/v3/dtoreflectiveassert/DtoReflectiveAssertRest.kt
@@ -1,0 +1,39 @@
+package com.foo.rest.examples.spring.openapi.v3.dtoreflectiveassert
+
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class DtoReflectiveAssertRest {
+
+    @PostMapping(path = ["/allof"], consumes = [MediaType.APPLICATION_JSON_VALUE])
+    open fun allof(@RequestBody body: AllOfDto) : ResponseEntity<String>{
+        return ResponseEntity.ok("OK")
+    }
+
+    // TODO: Restore when support for ChoiceGene has been added
+//    @PostMapping(path = ["/anyof"], consumes = [MediaType.APPLICATION_JSON_VALUE])
+//    open fun anyof(@RequestBody body: AnyOfDto) : ResponseEntity<String>{
+//        return ResponseEntity.ok("OK")
+//    }
+
+    // TODO: Restore when support for ChoiceGene has been added
+//    @PostMapping(path = ["/oneof"], consumes = [MediaType.APPLICATION_JSON_VALUE])
+//    open fun oneof(@RequestBody body: OneOfDto) : ResponseEntity<String>{
+//        return ResponseEntity.ok("OK")
+//    }
+
+    @PostMapping(path = ["/primitiveTypes"], consumes = [MediaType.APPLICATION_JSON_VALUE])
+    open fun primitiveTypes(@RequestBody body: PrimitiveTypesDto) : ResponseEntity<String>{
+        return ResponseEntity.ok("OK")
+    }
+
+    @PostMapping(path = ["/parent"], consumes = [MediaType.APPLICATION_JSON_VALUE])
+    open fun parent(@RequestBody body: ParentSchemaDto) : ResponseEntity<String>{
+        return ResponseEntity.ok("OK")
+    }
+
+}

--- a/core-tests/e2e-tests/spring-rest-openapi-v3/src/main/kotlin/com/foo/rest/examples/spring/openapi/v3/dtoreflectiveassert/OneOfDto.kt
+++ b/core-tests/e2e-tests/spring-rest-openapi-v3/src/main/kotlin/com/foo/rest/examples/spring/openapi/v3/dtoreflectiveassert/OneOfDto.kt
@@ -1,0 +1,8 @@
+package com.foo.rest.examples.spring.openapi.v3.dtoreflectiveassert
+
+class OneOfDto {
+
+    var cat: String = ""
+    var mouse: String = ""
+
+}

--- a/core-tests/e2e-tests/spring-rest-openapi-v3/src/main/kotlin/com/foo/rest/examples/spring/openapi/v3/dtoreflectiveassert/ParentSchemaDto.kt
+++ b/core-tests/e2e-tests/spring-rest-openapi-v3/src/main/kotlin/com/foo/rest/examples/spring/openapi/v3/dtoreflectiveassert/ParentSchemaDto.kt
@@ -1,0 +1,8 @@
+package com.foo.rest.examples.spring.openapi.v3.dtoreflectiveassert
+
+class ParentSchemaDto {
+
+    var label: String = ""
+    var child: ChildSchemaDto = ChildSchemaDto()
+
+}

--- a/core-tests/e2e-tests/spring-rest-openapi-v3/src/main/kotlin/com/foo/rest/examples/spring/openapi/v3/dtoreflectiveassert/PrimitiveTypesDto.kt
+++ b/core-tests/e2e-tests/spring-rest-openapi-v3/src/main/kotlin/com/foo/rest/examples/spring/openapi/v3/dtoreflectiveassert/PrimitiveTypesDto.kt
@@ -1,0 +1,17 @@
+package com.foo.rest.examples.spring.openapi.v3.dtoreflectiveassert
+
+class PrimitiveTypesDto {
+
+    var aString: String = ""
+    var aRegex: String = ""
+    var aDate: String = ""
+    var aTime: String = ""
+    var aDateTime: String = ""
+    var anInteger: Int = -1
+    var aLong: Long = -1L
+    var aDouble: Double = -1.0
+    var aFloat: Float = -1.0f
+    var aBoolean: Boolean = false
+    var aNullableString: String? = null
+
+}

--- a/core-tests/e2e-tests/spring-rest-openapi-v3/src/main/resources/static/openapi-dto-reflective-assert.yaml
+++ b/core-tests/e2e-tests/spring-rest-openapi-v3/src/main/resources/static/openapi-dto-reflective-assert.yaml
@@ -1,0 +1,172 @@
+openapi: 3.0.3
+info:
+  title: allOf with Component Schemas
+  version: 1.0.0
+
+paths:
+  /primitiveTypes:
+    post:
+      summary: Example with all primitive and format types (no array/object)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                aString:
+                  type: string
+                aRegex:
+                  type: string
+                  pattern: "^[a-zA-Z0-9]+$"
+                aDate:
+                  type: string
+                  format: date
+                aTime:
+                  type: string
+                  format: time
+                aDateTime:
+                  type: string
+                  format: date-time
+                anInteger:
+                  type: integer
+                aLong:
+                  type: integer
+                  format: int64
+                aDouble:
+                  type: number
+                aFloat:
+                  type: number
+                  format: float
+                aBoolean:
+                  type: boolean
+                aNullableString:
+                  type: string
+                  nullable: true
+              required:
+                - aString
+                - aRegex
+                - aBase64String
+                - aDate
+                - aTime
+                - aDateTime
+                - anInteger
+                - aLong
+                - aDouble
+                - aFloat
+                - aBoolean
+      responses:
+        '200':
+          description: OK
+  /parent:
+    post:
+      summary: Uses ParentSchema, which references ChildSchema
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ParentSchema'
+      responses:
+        '200':
+          description: OK
+  /allof:
+    post:
+      summary: Combines two components NamePart and AgePart
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/NamePart'
+                - $ref: '#/components/schemas/AgePart'
+      responses:
+        '200':
+          description: OK
+# TODO: Restore when support for ChoiceGene has been added
+#  /anyof:
+#    post:
+#      summary: Accepts either an email (component) or phone (inline)
+#      requestBody:
+#        required: true
+#        content:
+#          application/json:
+#            schema:
+#              anyOf:
+#                - $ref: '#/components/schemas/EmailPayload'
+#                - type: object
+#                  required: [phone]
+#                  properties:
+#                    phone:
+#                      type: string
+#      responses:
+#        '200':
+#          description: OK
+#  /oneof:
+#    post:
+#      summary: Accepts either cat or dog object (but not both)
+#      requestBody:
+#        required: true
+#        content:
+#          application/json:
+#            schema:
+#              oneOf:
+#                - type: object
+#                  required: [cat]
+#                  properties:
+#                    cat:
+#                      type: string
+#                - type: object
+#                  required: [mouse]
+#                  properties:
+#                    mouse:
+#                      type: string
+#      responses:
+#        '200':
+#          description: OK
+
+components:
+  schemas:
+    NamePart:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+
+    AgePart:
+      type: object
+      required: [age]
+      properties:
+        age:
+          type: integer
+
+    EmailPayload:
+      type: object
+      required: [email]
+      properties:
+        email:
+          type: string
+
+    ParentSchema:
+      type: object
+      properties:
+        label:
+          type: string
+        child:
+          $ref: '#/components/schemas/ChildSchema'
+      required:
+        - label
+        - child
+
+    ChildSchema:
+      type: object
+      properties:
+        name:
+          type: string
+        age:
+          type: integer
+      required:
+        - name
+        - age

--- a/core-tests/e2e-tests/spring-rest-openapi-v3/src/main/resources/static/openapi-dto.yml
+++ b/core-tests/e2e-tests/spring-rest-openapi-v3/src/main/resources/static/openapi-dto.yml
@@ -2,8 +2,6 @@ openapi: 3.0.0
 info:
   title: Simple DTO API
   version: 1.0.0
-#servers:
-#  - url: http://localhost:8080
 paths:
   /object:
     post:

--- a/core-tests/e2e-tests/spring-rest-openapi-v3/src/test/kotlin/com/foo/rest/examples/spring/openapi/v3/dtoreflectiveassert/DtoReflectiveAssertController.kt
+++ b/core-tests/e2e-tests/spring-rest-openapi-v3/src/test/kotlin/com/foo/rest/examples/spring/openapi/v3/dtoreflectiveassert/DtoReflectiveAssertController.kt
@@ -1,0 +1,15 @@
+package com.foo.rest.examples.spring.openapi.v3.dtoreflectiveassert
+
+import com.foo.rest.examples.spring.openapi.v3.SpringController
+import org.evomaster.client.java.controller.problem.ProblemInfo
+import org.evomaster.client.java.controller.problem.RestProblem
+
+class DtoReflectiveAssertController : SpringController(DtoReflectiveAssertApplication::class.java){
+
+    override fun getProblemInfo(): ProblemInfo {
+        return RestProblem(
+            "http://localhost:$sutPort/openapi-dto-reflective-assert.yaml",
+            null
+        )
+    }
+}

--- a/core-tests/e2e-tests/spring-rest-openapi-v3/src/test/kotlin/org/evomaster/e2etests/spring/openapi/v3/dtoreflectiveassert/DtoReflectiveAssertEMTest.kt
+++ b/core-tests/e2e-tests/spring-rest-openapi-v3/src/test/kotlin/org/evomaster/e2etests/spring/openapi/v3/dtoreflectiveassert/DtoReflectiveAssertEMTest.kt
@@ -1,0 +1,113 @@
+package org.evomaster.e2etests.spring.openapi.v3.dtoreflectiveassert
+
+import com.foo.rest.examples.spring.openapi.v3.dtoreflectiveassert.DtoReflectiveAssertController
+import org.evomaster.client.java.instrumentation.shared.ClassName
+import org.evomaster.core.problem.rest.data.HttpVerb
+import org.evomaster.e2etests.spring.openapi.v3.SpringTestBase
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import kotlin.reflect.KClass
+import kotlin.reflect.KMutableProperty1
+import kotlin.reflect.full.createInstance
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.isAccessible
+
+class DtoReflectiveAssertEMTest: SpringTestBase() {
+
+    companion object {
+        @BeforeAll
+        @JvmStatic
+        fun init() {
+            initClass(DtoReflectiveAssertController())
+        }
+    }
+
+    @Test
+    fun testRunEM() {
+        runTestHandlingFlakyAndCompilation(
+            "ReflectiveAssertEM",
+            "org.foo.ReflectiveAssertEM",
+            100,
+        ) { args: MutableList<String> ->
+
+            setOption(args,"dtoForRequestPayload","true")
+
+            val solution = initAndRun(args)
+
+            Assertions.assertTrue(solution.individuals.size >= 1)
+            assertHasAtLeastOne(solution, HttpVerb.POST, 200, "/allof", "OK")
+            assertHasAtLeastOne(solution, HttpVerb.POST, 200, "/primitiveTypes", "OK")
+            assertHasAtLeastOne(solution, HttpVerb.POST, 200, "/parent", "OK")
+        }
+
+        assertPrimitiveTypeDtoCreated()
+        assertParentAndChildDtosCreated()
+        assertAllOfDtoCreated()
+        // TODO: Restore when support for ChoiceGene has been added
+//        assertAnyOfDtoCreated()
+//        assertOneOfDtoCreated()
+    }
+
+    private fun assertPrimitiveTypeDtoCreated() {
+        val (klass, instance) = initDtoClass("POST__primitiveTypes")
+        assertProperty(klass, instance, "aString", "hello")
+        assertProperty(klass, instance, "aRegex", "^[a-zA-Z0-9]+\\$")
+        assertProperty(klass, instance, "aDate", "2025-08-03")
+        assertProperty(klass, instance, "aTime", "14:30:00")
+        assertProperty(klass, instance, "aDateTime", "2025-08-03T14:30:00Z")
+        assertProperty(klass, instance, "anInteger", -3)
+        assertProperty(klass, instance, "aLong", 9223372036854775807L)
+        assertProperty(klass, instance, "aDouble", 3.1415)
+        assertProperty(klass, instance, "aFloat", 2.718f)
+        assertProperty(klass, instance, "aBoolean", true)
+        assertProperty(klass, instance, "aNullableString", null)
+    }
+
+    private fun assertParentAndChildDtosCreated() {
+        val (parentKlass, parentInstance) = initDtoClass("ParentSchema")
+        val (childKass, childInstance) = initDtoClass("ChildSchema")
+        assertProperty(childKass, childInstance, "name", "Philip")
+        assertProperty(childKass, childInstance, "age", 31)
+        assertProperty(parentKlass, parentInstance, "label", "EM_TEST")
+        assertProperty(parentKlass, parentInstance, "child", childInstance)
+    }
+
+    private fun assertAllOfDtoCreated() {
+        val (klass, instance) = initDtoClass("POST__allof")
+        assertProperty(klass, instance, "name", "Philip")
+        assertProperty(klass, instance, "age", 31)
+    }
+
+    private fun assertAnyOfDtoCreated() {
+        val (klass, instance) = initDtoClass("POST__anyof")
+        assertProperty(klass, instance, "email", "evomaster@webfuzzing.com")
+        assertProperty(klass, instance, "phone", "+54123151")
+    }
+
+    private fun assertOneOfDtoCreated() {
+        val (klass, instance) = initDtoClass("POST__oneof")
+        assertProperty(klass, instance, "cat", "Tom")
+        assertProperty(klass, instance, "mouse", "Jerry")
+    }
+
+    private fun initDtoClass(name: String): Pair<KClass<out Any>, Any> {
+        val className = ClassName("org.foo.dto.$name")
+        val klass = loadClass(className).kotlin
+        Assertions.assertNotNull(klass)
+        return Pair(klass, klass.createInstance())
+    }
+
+    private fun assertProperty(klass: KClass<out Any>, instance: Any, propertyName: String, propertyValue: Any?) {
+        val property = klass.memberProperties
+            .firstOrNull { it.name == propertyName } as? KMutableProperty1<Any, Any?>
+        Assertions.assertNotNull(property)
+
+        property?.let {
+            it.isAccessible = true
+            it.set(instance, propertyValue) // Set the value
+        }
+        Assertions.assertEquals(propertyValue, property?.get(instance))
+    }
+
+}

--- a/core/src/test/kotlin/org/evomaster/core/output/dto/DtoWriterTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/output/dto/DtoWriterTest.kt
@@ -80,103 +80,6 @@ class DtoWriterTest {
     }
 
     @Test
-    fun primitiveTypesAreCollectedAsDtoFields() {
-        val dtoWriter = DtoWriter(outputFormat)
-        val actionCluster = initRestSchema("primitiveTypes.yaml")
-
-        dtoWriter.write(outputTestSuitePath, TEST_PACKAGE, MOCK_SOLUTION)
-
-        val collectedDtos = dtoWriter.getCollectedDtos()
-        assertEquals(collectedDtos.size, 1)
-        val postExampleDto = collectedDtos["POST__example"]
-        assertNotNull(postExampleDto)
-        val dtoFields = postExampleDto?.fields?:emptyList()
-        assertEquals(dtoFields.size, 12)
-        assertDtoFieldIn(dtoFields, "aString", STRING)
-        assertDtoFieldIn(dtoFields, "aRegex", STRING)
-        assertDtoFieldIn(dtoFields, "aBase64String", STRING)
-        assertDtoFieldIn(dtoFields, "aDate", STRING)
-        assertDtoFieldIn(dtoFields, "aTime", STRING)
-        assertDtoFieldIn(dtoFields, "aDateTime", STRING)
-        assertDtoFieldIn(dtoFields, "anInteger", INTEGER)
-        assertDtoFieldIn(dtoFields, "aLong", "Long")
-        assertDtoFieldIn(dtoFields, "aNumber", "Double")
-        assertDtoFieldIn(dtoFields, "aFloat", "Float")
-        assertDtoFieldIn(dtoFields, "aBoolean", BOOLEAN)
-        assertDtoFieldIn(dtoFields, "aNullableString", STRING)
-    }
-
-    @Test
-    fun childObjectInlineIsCollectedInDto() {
-        val dtoWriter = DtoWriter(outputFormat)
-        val actionCluster = initRestSchema("object/childObjectInline.yaml")
-
-        dtoWriter.write(outputTestSuitePath, TEST_PACKAGE, MOCK_SOLUTION)
-
-        val collectedDtos = dtoWriter.getCollectedDtos()
-        assertEquals(collectedDtos.size, 2)
-        val postExampleDto = collectedDtos["POST__example"]
-        assertNotNull(postExampleDto)
-        val dtoFields = postExampleDto?.fields?:emptyList()
-        assertEquals(dtoFields.size, 2)
-        assertDtoFieldIn(dtoFields, "aString", STRING)
-        assertDtoFieldIn(dtoFields, "anObject", "Anobject")
-
-        val childObjectDto = collectedDtos["Anobject"]
-        assertNotNull(childObjectDto)
-        val childObjectDtoFields = childObjectDto?.fields?:emptyList()
-        assertEquals(childObjectDtoFields.size, 2)
-        assertDtoFieldIn(childObjectDtoFields, "name", STRING)
-        assertDtoFieldIn(childObjectDtoFields, "age", INTEGER)
-    }
-
-    @Test
-    fun whenUsingComponentsDtoNameIsSchemaName() {
-        val dtoWriter = DtoWriter(outputFormat)
-        val actionCluster = initRestSchema("object/simpleComponents.yaml")
-
-        dtoWriter.write(outputTestSuitePath, TEST_PACKAGE, MOCK_SOLUTION)
-
-        val collectedDtos = dtoWriter.getCollectedDtos()
-        assertEquals(collectedDtos.size, 2)
-        val firstSchema = collectedDtos["FirstSchema"]
-        assertNotNull(firstSchema)
-        val dtoFields = firstSchema?.fields?:emptyList()
-        assertEquals(dtoFields.size, 1)
-        assertDtoFieldIn(dtoFields, "message", STRING)
-
-        val secondSchema = collectedDtos["SecondSchema"]
-        assertNotNull(secondSchema)
-        val childObjectDtoFields = secondSchema?.fields?:emptyList()
-        assertEquals(childObjectDtoFields.size, 1)
-        assertDtoFieldIn(childObjectDtoFields, "active", BOOLEAN)
-    }
-
-    @Test
-    fun childObjectComponentIsCollectedInDto() {
-        val dtoWriter = DtoWriter(outputFormat)
-        val actionCluster = initRestSchema("object/childObjectComponent.yaml")
-
-        dtoWriter.write(outputTestSuitePath, TEST_PACKAGE, MOCK_SOLUTION)
-
-        val collectedDtos = dtoWriter.getCollectedDtos()
-        assertEquals(collectedDtos.size, 2)
-        val postExampleDto = collectedDtos["ParentSchema"]
-        assertNotNull(postExampleDto)
-        val dtoFields = postExampleDto?.fields?:emptyList()
-        assertEquals(dtoFields.size, 2)
-        assertDtoFieldIn(dtoFields, "label", STRING)
-        assertDtoFieldIn(dtoFields, "child", "ChildSchema")
-
-        val childObjectDto = collectedDtos["ChildSchema"]
-        assertNotNull(childObjectDto)
-        val childObjectDtoFields = childObjectDto?.fields?:emptyList()
-        assertEquals(childObjectDtoFields.size, 2)
-        assertDtoFieldIn(childObjectDtoFields, "name", STRING)
-        assertDtoFieldIn(childObjectDtoFields, "age", INTEGER)
-    }
-
-    @Test
     fun arrayAsRootTypeCollectsASingleDto() {
         val dtoWriter = DtoWriter(outputFormat)
         val actionCluster = initRestSchema("array/rootArrayWithComponents.yaml")
@@ -306,24 +209,6 @@ class DtoWriterTest {
     }
 
     @Test
-    fun testAnyOfMergesDtosIntoASingleOne() {
-        val dtoSpecs = listOf("Components", "Inline", "MixedOptional")
-        dtoSpecs.forEach { chosenDto ->
-            val dtoWriter = DtoWriter(outputFormat)
-            val actionCluster = initRestSchema("choice/anyOf$chosenDto.yaml")
-            dtoWriter.write(outputTestSuitePath, TEST_PACKAGE, MOCK_SOLUTION)
-            val collectedDtos = dtoWriter.getCollectedDtos()
-            assertEquals(collectedDtos.size, 1)
-            val anyOfDto = collectedDtos[collectedDtos.keys.first()]
-            assertNotNull(anyOfDto)
-            val dtoFields = anyOfDto?.fields?:emptyList()
-            assertEquals(dtoFields.size, 2)
-            assertDtoFieldIn(dtoFields, "phone", STRING)
-            assertDtoFieldIn(dtoFields, "email", STRING)
-        }
-    }
-
-    @Test
     fun testAnyOfArrayAndObject() {
         val chosenDto = "ArrayAndObject"
         val dtoWriter = DtoWriter(outputFormat)
@@ -337,24 +222,6 @@ class DtoWriterTest {
         assertEquals(dtoFields.size, 2)
         assertDtoFieldIn(dtoFields, "email", STRING)
         assertDtoFieldIn(dtoFields, "numbers", "List<Integer>")
-    }
-
-    @Test
-    fun testAllOfMergesDtosIntoASingleOne() {
-        val dtoSpecs = listOf("Components", "Inline", "Mixed")
-        dtoSpecs.forEach { chosenDto ->
-            val dtoWriter = DtoWriter(outputFormat)
-            val actionCluster = initRestSchema("choice/allOf$chosenDto.yaml")
-            dtoWriter.write(outputTestSuitePath, TEST_PACKAGE, MOCK_SOLUTION)
-            val collectedDtos = dtoWriter.getCollectedDtos()
-            assertEquals(collectedDtos.size, 1)
-            val allOfDto = collectedDtos[collectedDtos.keys.first()]
-            assertNotNull(allOfDto)
-            val dtoFields = allOfDto?.fields?:emptyList()
-            assertEquals(dtoFields.size, 2)
-            assertDtoFieldIn(dtoFields, "name", STRING)
-            assertDtoFieldIn(dtoFields, "age", INTEGER)
-        }
     }
 
     @Test


### PR DESCRIPTION
Since we changed the way that DTOs are extracted in [PR-1342](https://github.com/WebFuzzing/EvoMaster/pull/1342), this PR adds assertions to ensure that the created DTO classes contain the fields that are expected. This is done by means of reflection, using the generated Kotlin files and then setting and retrieving values.

Replaces [PR-1366](https://github.com/WebFuzzing/EvoMaster/pull/1366) due to merge mistake.