### PR TITLE
refactor: moving mongo classes to internal.db.mongo

### DIFF
--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/internal/SutController.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/internal/SutController.java
@@ -33,7 +33,7 @@ import org.evomaster.client.java.sql.DbCleaner;
 import org.evomaster.client.java.sql.SqlScriptRunner;
 import org.evomaster.client.java.sql.SqlScriptRunnerCached;
 import org.evomaster.client.java.sql.DbSpecification;
-import org.evomaster.client.java.controller.internal.db.MongoHandler;
+import org.evomaster.client.java.controller.internal.db.mongo.MongoHandler;
 import org.evomaster.client.java.sql.DbInfoExtractor;
 import org.evomaster.client.java.sql.internal.SqlHandler;
 import org.evomaster.client.java.controller.mongo.MongoScriptRunner;

--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/internal/db/mongo/MongoCommandWithDistance.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/internal/db/mongo/MongoCommandWithDistance.java
@@ -1,4 +1,4 @@
-package org.evomaster.client.java.controller.internal.db;
+package org.evomaster.client.java.controller.internal.db.mongo;
 
 public class MongoCommandWithDistance {
 

--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/internal/db/mongo/MongoDistanceWithMetrics.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/internal/db/mongo/MongoDistanceWithMetrics.java
@@ -1,4 +1,4 @@
-package org.evomaster.client.java.controller.internal.db;
+package org.evomaster.client.java.controller.internal.db.mongo;
 
 public class MongoDistanceWithMetrics {
 

--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/internal/db/mongo/MongoHandler.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/internal/db/mongo/MongoHandler.java
@@ -1,4 +1,4 @@
-package org.evomaster.client.java.controller.internal.db;
+package org.evomaster.client.java.controller.internal.db.mongo;
 
 import org.evomaster.client.java.controller.api.dto.database.execution.MongoFailedQuery;
 import org.evomaster.client.java.controller.api.dto.database.execution.MongoExecutionsDto;

--- a/client-java/controller/src/test/java/org/evomaster/client/java/controller/internal/db/mongo/MongoDistanceWithMetricsTest.java
+++ b/client-java/controller/src/test/java/org/evomaster/client/java/controller/internal/db/mongo/MongoDistanceWithMetricsTest.java
@@ -1,4 +1,4 @@
-package org.evomaster.client.java.controller.internal.db;
+package org.evomaster.client.java.controller.internal.db.mongo;
 
 import org.junit.jupiter.api.Test;
 

--- a/client-java/controller/src/test/java/org/evomaster/client/java/controller/internal/db/mongo/MongoHandlerTest.java
+++ b/client-java/controller/src/test/java/org/evomaster/client/java/controller/internal/db/mongo/MongoHandlerTest.java
@@ -3,8 +3,6 @@ package org.evomaster.client.java.controller.internal.db.mongo;
 import com.mongodb.client.*;
 import org.bson.Document;
 import org.bson.conversions.Bson;
-import org.evomaster.client.java.controller.internal.db.MongoHandler;
-import org.evomaster.client.java.controller.internal.db.MongoCommandWithDistance;
 import org.evomaster.client.java.instrumentation.MongoFindCommand;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
The changed files now appear as moved instead of new classes. I am not sure why it failed in the last PR.