### PR TITLE
Fixing markdown table for internal options on Options.md

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/docs/ConfigToMarkdown.kt
+++ b/core/src/main/kotlin/org/evomaster/core/docs/ConfigToMarkdown.kt
@@ -6,6 +6,8 @@ import java.io.File
 import java.nio.charset.Charset
 import kotlin.reflect.KMutableProperty
 import kotlin.reflect.jvm.javaType
+import org.apache.commons.text.WordUtils
+
 /**
  * Class used to generate Markdown documentation for [EMConfig]
  */
@@ -53,11 +55,10 @@ object ConfigToMarkdown {
                             to modify. These were mainly introduced when experimenting with 
                             different configurations to maximize the performance of _EvoMaster_. 
                             Some of these options are used to collect more info on the search, to help
-                            debugging issues in _EvoMaster_ itself.                                   
+                            debugging issues in _EvoMaster_ itself.
                             
             * __Experimental__: these are work-in-progress options, for features still under development
-                                and testing.        
-                     
+                                and testing.
 
              The list of available options can also be displayed by using `--help`, e.g.:
 
@@ -122,27 +123,12 @@ object ConfigToMarkdown {
     }
 
     private fun printOptionList(buffer: StringBuilder, list: List<KMutableProperty<*>>){
-
-        /*
-            Markdown-style tables have all column widths messed up, see:
-
-            https://stackoverflow.com/questions/36121672/set-table-column-width-via-markdown
-
-            however, if we use HTML, then we need to change all the formattings, eg ** and `` :-(
-         */
-
-        val awfulHackButWhatElseCanWeDo = "" //"<img width=2500/>"
-
-        buffer.append("|Options$awfulHackButWhatElseCanWeDo|Description|\n")
+        buffer.append("|Options|Description|\n")
         buffer.append("|---|---|\n")
-
-//        buffer.append("<table><thead><tr><th>Options</th><th>Description</th></tr></thead><tbody>")
 
         for(opt in list){
             printOption(buffer, opt)
         }
-
-//        buffer.append("</tbody></table>")
     }
 
     private fun printOption(buffer: StringBuilder, opt: KMutableProperty<*>) {
@@ -160,14 +146,7 @@ object ConfigToMarkdown {
 
         val description = EMConfig.getDescription(opt)
 
-//        buffer.append("<tr>")
-
-//        buffer.append("|<nobr>`--${opt.name}` &lt;$typeName&gt;</nobr>| ")
         buffer.append("|`${opt.name}`| ")
-
-//        buffer.append("<td><nobr>`--${opt.name}` &lt;$typeName&gt;</nobr></td>")
-
-//        buffer.append("<td>")
 
         buffer.append("__${typeName}__. ")
 
@@ -181,11 +160,7 @@ object ConfigToMarkdown {
         }
 
         if(description.constraints.isNotBlank()){
-            /*
-                see https://stackoverflow.com/questions/17319940/how-to-escape-a-pipe-char-in-a-code-statement-in-a-markdown-table
-                GitHub supports it, but current IDEA Viewer does not
-             */
-            buffer.append(" *Constraints*: `${description.constraints.replace("|","\\|")}`.")
+            buffer.append(" *Constraints*: ${formatConstraintForMarkdownTable(description.constraints)}.")
         }
 
         if(description.dependsOn.isNotBlank()){
@@ -194,18 +169,47 @@ object ConfigToMarkdown {
 
         if (description.enumValidValues.isNotBlank()) {
             buffer.append(" *Valid values*: `${description.enumValidValues}`.")
-          }
+        }
 
         if (description.enumExperimentalValues.isNotBlank()) {
             buffer.append(" *Experimental values*: `${description.enumExperimentalValues}`.")
         }
 
         buffer.append(" *Default value*: `$default`.")
-
-//        buffer.append("</td></tr>")
         buffer.append("|\n")
     }
 
+    private fun formatConstraintForMarkdownTable(constraint: String): String {
+        /*
+            Markdown table cells break when containing unescaped '|' characters.
+            For long values, wrap at safe boundaries to avoid breaking expressions
+            in the middle while keeping lines around a readable width.
+         */
+        val escaped = constraint.replace("|", "\\|")
+        if (escaped.length <= 80) {
+            return "`$escaped`"
+        }
 
+        val marker = "__EM_WRAP__"
+        // Add a hint to the table cell that the value should be wrapped
+        val withHints = escaped
+            .replace("\\|", "\\|$marker ")
+            .replace(";", ";$marker ")
+            .replace(",", ",$marker ")
+        // Wrap and remove the hints
+        val wrapped = WordUtils.wrap(withHints, 80, "\n", false)
+            .replace("$marker ", "")
+            .replace(marker, "")
 
+        return wrapped.lineSequence()
+            .map { htmlEscape(it.trimEnd()) }
+            .joinToString("<br>")
+    }
+
+    private fun htmlEscape(text: String): String {
+        return text
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+    }
 }

--- a/docs/options.md
+++ b/docs/options.md
@@ -12,11 +12,10 @@ There are 3 types of options:
                 to modify. These were mainly introduced when experimenting with 
                 different configurations to maximize the performance of _EvoMaster_. 
                 Some of these options are used to collect more info on the search, to help
-                debugging issues in _EvoMaster_ itself.                                   
+                debugging issues in _EvoMaster_ itself.
                 
 * __Experimental__: these are work-in-progress options, for features still under development
-                    and testing.        
-         
+                    and testing.
 
  The list of available options can also be displayed by using `--help`, e.g.:
 
@@ -115,7 +114,7 @@ There are 3 types of options:
 |`endNumberOfMutations`| __Int__. Number of applied mutations on sampled individuals, by the end of the search. *Constraints*: `min=0.0`. *Default value*: `10`.|
 |`errorTextEpsilon`| __Double__. The Distance Metric Error Text may use several values for epsilon.During experimentation, it may be useful to adjust these values. Epsilon describes the size of the neighbourhood used for clustering, so may result in different clustering results.Epsilon should be between 0.0 and 1.0. If the value is outside of that range, epsilon will use the default of 0.8. *Constraints*: `min=0.0, max=1.0`. *Default value*: `0.8`.|
 |`exceedTargetsFile`| __String__. Specify a path to save all not covered targets when the number is more than 100. *DEBUG option*. *Default value*: `exceedTargets.txt`.|
-|`excludeTargetsForImpactCollection`| __String__. Specify prefixes of targets (e.g., MethodReplacement, Success_Call, Local) which will exclude in impact collection. Multiple exclusions should be separated with semicolon (i.e., ;). *Constraints*: `regex ^(\b(None\|NONE\|none)\b\|(\b(Class\|CLASS\|class\|Line\|LINE\|line\|Branch\|BRANCH\|branch\|MethodReplacement\|METHODREPLACEMENT\|method[r\|R]eplacement\|Success_Call\|SUCCESS_CALL\|success_[c\|C]all\|Local\|LOCAL\|local\|PotentialFault\|POTENTIALFAULT\|potential[f\|F]ault)\b(;\b(Class\|CLASS\|class\|Line\|LINE\|line\|Branch\|BRANCH\|branch\|MethodReplacement\|METHODREPLACEMENT\|method[r\|R]eplacement\|Success_Call\|SUCCESS_CALL\|success_[c\|C]all\|Local\|LOCAL\|local\|PotentialFault\|POTENTIALFAULT\|potential[f\|F]ault)\b)*))$`. *Default value*: `Local;MethodReplacement`.|
+|`excludeTargetsForImpactCollection`| __String__. Specify prefixes of targets (e.g., MethodReplacement, Success_Call, Local) which will exclude in impact collection. Multiple exclusions should be separated with semicolon (i.e., ;). *Constraints*: regex ^(\b(None\|NONE\|none)\b\|<br>(\b(Class\|CLASS\|class\|Line\|<br>LINE\|line\|Branch\|BRANCH\|<br>branch\|MethodReplacement\|<br>METHODREPLACEMENT\|method[r\|R]eplacement\|<br>Success_Call\|SUCCESS_CALL\|success_[c\|<br>C]all\|Local\|LOCAL\|local\|<br>PotentialFault\|POTENTIALFAULT\|potential[f\|<br>F]ault)\b(;\b(Class\|CLASS\|<br>class\|Line\|LINE\|line\|<br>Branch\|BRANCH\|branch\|<br>MethodReplacement\|METHODREPLACEMENT\|<br>method[r\|R]eplacement\|Success_Call\|<br>SUCCESS_CALL\|success_[c\|C]all\|<br>Local\|LOCAL\|local\|<br>PotentialFault\|POTENTIALFAULT\|potential[f\|<br>F]ault)\b)*))$. *Default value*: `Local;MethodReplacement`.|
 |`expandRestIndividuals`| __Boolean__. Enable to expand the genotype of REST individuals based on runtime information missing from Swagger. *Default value*: `true`.|
 |`exportCoveredTarget`| __Boolean__. Specify whether to export covered targets info. *Default value*: `false`.|
 |`exportDependencies`| __Boolean__. Specify whether to export derived dependencies among resources. *DEBUG option*. *Default value*: `false`.|
@@ -275,7 +274,7 @@ There are 3 types of options:
 |`exportTestCasesDuringSeeding`| __Boolean__. Whether to export test cases during seeding as a separate file. *Default value*: `false`.|
 |`externalRequestHarvesterNumberOfThreads`| __Int__. Number of threads for external request harvester. No more threads than numbers of processors will be used. *Constraints*: `min=1.0`. *Default value*: `2`.|
 |`externalRequestResponseSelectionStrategy`| __Enum__. Harvested external request response selection strategy. *Valid values*: `EXACT, CLOSEST_SAME_DOMAIN, CLOSEST_SAME_PATH, RANDOM`. *Default value*: `EXACT`.|
-|`externalServiceIP`| __String__. User provided external service IP. When EvoMaster mocks external services, mock server instances will run on local addresses starting from this provided address. Min value is 127.0.0.4. Lower values like 127.0.0.2 and 127.0.0.3 are reserved. *Constraints*: `regex (?!^0*127(\.0*0){2}\.0*[0123]$)^0*127(\.0*(25[0-5]\|2[0-4][0-9]\|1?[0-9]?[0-9])){3}$`. *Default value*: `127.0.0.4`.|
+|`externalServiceIP`| __String__. User provided external service IP. When EvoMaster mocks external services, mock server instances will run on local addresses starting from this provided address. Min value is 127.0.0.4. Lower values like 127.0.0.2 and 127.0.0.3 are reserved. *Constraints*: regex (?!^0*127(\.0*0){2}\.0*[0123]$)^0*127(\.0*(25[0-5]\|<br>2[0-4][0-9]\|1?[0-9]?[0-9])){3}$. *Default value*: `127.0.0.4`.|
 |`externalServiceIPSelectionStrategy`| __Enum__. Specify a method to select the first external service spoof IP address. *Valid values*: `NONE, DEFAULT, USER, RANDOM`. *Default value*: `NONE`.|
 |`generateSqlDataWithDSE`| __Boolean__. Enable EvoMaster to generate SQL data with direct accesses to the database. Use Dynamic Symbolic Execution. *Depends on*: `blackBox=false`. *Default value*: `false`.|
 |`handleFlakiness`| __Boolean__. Specify whether to detect flakiness and handle the flakiness in assertions during post handling of fuzzing. Note that flakiness is now supported only for fuzzing REST APIs. *Default value*: `false`.|


### PR DESCRIPTION
The current internal options table is rendering without line wraps because of a very long regular expression. Additionally removed a hack as the table now renders fine in Github and Intellij without it.