### PR TITLE
Minor clean up of Maven dependencies

### DIFF
--- a/client-java/pom.xml
+++ b/client-java/pom.xml
@@ -8,7 +8,6 @@
         <version>5.1.1-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.evomaster</groupId>
     <artifactId>evomaster-client-java</artifactId>
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>

--- a/core-extra/solver/pom.xml
+++ b/core-extra/solver/pom.xml
@@ -9,7 +9,6 @@
         <version>5.1.1-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.evomaster</groupId>
     <artifactId>solver</artifactId>
 
     <dependencies>
@@ -21,10 +20,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/core-tests/e2e-tests/spring/spring-graphql-bb/pom.xml
+++ b/core-tests/e2e-tests/spring/spring-graphql-bb/pom.xml
@@ -60,10 +60,6 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>
@@ -77,10 +73,6 @@
             <groupId>org.evomaster</groupId>
             <artifactId>evomaster-e2e-tests-utils</artifactId>
             <type>test-jar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.evomaster</groupId>
-            <artifactId>evomaster-client-java-controller</artifactId>
         </dependency>
         <dependency>
             <groupId>org.evomaster</groupId>

--- a/core-tests/e2e-tests/spring/spring-graphql/pom.xml
+++ b/core-tests/e2e-tests/spring/spring-graphql/pom.xml
@@ -60,10 +60,6 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>
@@ -72,10 +68,6 @@
             <groupId>org.evomaster</groupId>
             <artifactId>evomaster-e2e-tests-utils</artifactId>
             <type>test-jar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.evomaster</groupId>
-            <artifactId>evomaster-client-java-controller</artifactId>
         </dependency>
         <dependency>
             <groupId>org.evomaster</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -170,7 +170,7 @@
             <artifactId>javax.el</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -353,9 +353,9 @@
                 <version>1.9</version>
             </dependency>
             <dependency>
-                <groupId>org.hibernate</groupId>
+                <groupId>org.hibernate.validator</groupId>
                 <artifactId>hibernate-validator</artifactId>
-                <version>6.1.0.Final</version>
+                <version>6.2.0.Final</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
Removed Maven build warnings by cleaning up duplicate and unused dependencies. Hibernate validator package was renamed. sl4j in Solver caused a conflict with Logback LoggerFactory when launching applications. All tests passing.