### PR TITLE
Skip class replacement on known classloaders to avoid noisy warning

### DIFF
--- a/client-java/instrumentation/src/main/java/org/evomaster/client/java/instrumentation/ClassesToExclude.java
+++ b/client-java/instrumentation/src/main/java/org/evomaster/client/java/instrumentation/ClassesToExclude.java
@@ -16,6 +16,9 @@ public class ClassesToExclude {
 
     private static final String EM_REPRESENTATIVE_CLASS = "org.evomaster.client.java.instrumentation.staticstate.ExecutionTracer";
     private static final String EM_CLASS_LOAD_ERROR_MSG = "Fail to load "+ EM_REPRESENTATIVE_CLASS;
+    //Adding a couple of known class loaders that are not able to load EM classes to avoid the above warning on every e2e test
+    private static final String PLATFORM_CLASS_LOADER = "jdk.internal.loader.ClassLoaders$PlatformClassLoader";
+    private static final String EXT_CLASS_LOADER = "sun.misc.Launcher$ExtClassLoader";
 
     static  {
 
@@ -70,6 +73,11 @@ public class ClassesToExclude {
             loader.loadClass(EM_REPRESENTATIVE_CLASS);
             return true;
         } catch (ClassNotFoundException e) {
+            //New logic to avoid logging an unnecessary warning on every test
+            String loaderName = loader.getClass().getName();
+            if (PLATFORM_CLASS_LOADER.equals(loaderName) || EXT_CLASS_LOADER.equals(loaderName)) {
+                return false;
+            }
             // reduce string concatenation, then only print the msg as EM_CLASS_LOAD_ERROR_MSG
             SimpleLogger.uniqueWarn(EM_CLASS_LOAD_ERROR_MSG);
             return false;
@@ -77,12 +85,6 @@ public class ClassesToExclude {
     }
 
     public static boolean checkIfCanInstrument(ClassLoader loader, ClassName cn) {
-
-        /*
-            if the loader cannot load EM classes, we skip instrumentation for the class, ie, cn
-         */
-        if (loader != null && !canLoadEMClass(loader))
-            return false;
 
         String className = cn.getFullNameWithDots();
 
@@ -98,6 +100,12 @@ public class ClassesToExclude {
                 return false;
             }
         }
+
+        /*
+            if the loader cannot load EM classes, we skip instrumentation for the class, ie, cn
+         */
+        if (loader != null && !canLoadEMClass(loader))
+            return false;
 
         return true;
     }


### PR DESCRIPTION
Avoid unnecessary warning to the user on every e2e test run. This warning also showed up when running generated tests to run on the SUT code base and made me waste a couple of hours as I was working on interception/method replacement. Overall I think this will save many hours for new developers.