### PR TITLE
Introduce Build metrics step and upgrade CI Actions to Node 24 compatible versions.

### DIFF
--- a/.github/actions/full-build-metrics/action.yml
+++ b/.github/actions/full-build-metrics/action.yml
@@ -94,7 +94,7 @@ runs:
         fi
 
     - name: Upload current metrics artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: ${{ inputs.artifact-name }}
         path: build-metrics.env

--- a/.github/actions/full-build-metrics/action.yml
+++ b/.github/actions/full-build-metrics/action.yml
@@ -27,7 +27,7 @@ runs:
   using: composite
   steps:
     - name: Download previous metrics artifact
-      uses: dawidd6/action-download-artifact@v9
+      uses: dawidd6/action-download-artifact@v20
       with:
         workflow: ${{ inputs.workflow-file }}
         workflow_conclusion: success
@@ -90,13 +90,20 @@ runs:
         } >> "$GITHUB_STEP_SUMMARY"
 
         if [ "${regression}" = "true" ]; then
-          exit 1
+          echo "METRICS_REGRESSION=true" >> "$GITHUB_ENV"
+        else
+          echo "METRICS_REGRESSION=false" >> "$GITHUB_ENV"
         fi
 
     - name: Upload current metrics artifact
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.artifact-name }}
         path: build-metrics.env
         retention-days: ${{ inputs.retention-days }}
         if-no-files-found: error
+
+    - name: Mark metrics regression
+      if: ${{ env.METRICS_REGRESSION == 'true' }}
+      shell: bash
+      run: exit 1

--- a/.github/actions/full-build-metrics/action.yml
+++ b/.github/actions/full-build-metrics/action.yml
@@ -1,0 +1,102 @@
+name: Full Build Metrics
+description: Count Maven warnings/errors, compare against latest successful baseline, and persist current metrics artifact
+
+inputs:
+  log-file:
+    description: Path to the captured build log
+    required: false
+    default: full-build-base.log
+  artifact-name:
+    description: Artifact name used to store metrics
+    required: false
+    default: full-build-base-metrics
+  baseline-branch:
+    description: Branch to fetch the latest successful baseline metrics from
+    required: false
+    default: master
+  workflow-file:
+    description: Workflow filename to query for baseline artifacts
+    required: false
+    default: ci.yml
+  retention-days:
+    description: Artifact retention period in days
+    required: false
+    default: "90"
+
+runs:
+  using: composite
+  steps:
+    - name: Download previous metrics artifact
+      uses: dawidd6/action-download-artifact@v9
+      with:
+        workflow: ${{ inputs.workflow-file }}
+        workflow_conclusion: success
+        branch: ${{ inputs.baseline-branch }}
+        name: ${{ inputs.artifact-name }}
+        path: previous-metrics
+        if_no_artifact_found: warn
+
+    - name: Count warnings/errors and compare
+      shell: bash
+      run: |
+        if [ -f "${{ inputs.log-file }}" ]; then
+          warnings_count=$(grep -c "^\[WARNING\]" "${{ inputs.log-file }}" || true)
+          errors_count=$(grep -c "^\[ERROR\]" "${{ inputs.log-file }}" || true)
+        else
+          warnings_count=9999999
+          errors_count=9999999
+        fi
+
+        previous_warnings=""
+        previous_errors=""
+        if [ -f previous-metrics/build-metrics.env ]; then
+          # shellcheck disable=SC1091
+          . previous-metrics/build-metrics.env
+          previous_warnings="${WARNINGS:-}"
+          previous_errors="${ERRORS:-}"
+        fi
+
+        echo "full-build-base warnings: ${warnings_count}"
+        echo "full-build-base errors: ${errors_count}"
+
+        regression=false
+        if [ -n "${previous_warnings}" ] && [ -n "${previous_errors}" ]; then
+          warnings_delta=$((warnings_count - previous_warnings))
+          errors_delta=$((errors_count - previous_errors))
+          echo "delta warnings vs last successful ${{ inputs.baseline-branch }} run: ${warnings_delta}"
+          echo "delta errors vs last successful ${{ inputs.baseline-branch }} run: ${errors_delta}"
+          if [ "${warnings_count}" -le "${previous_warnings}" ] && [ "${errors_count}" -le "${previous_errors}" ]; then
+            echo "Result: green (no increase in warnings or errors)."
+          else
+            echo "Result: yellow (warnings or errors increased)."
+            regression=true
+          fi
+        else
+          echo "No previous metrics artifact found on ${{ inputs.baseline-branch }} for comparison."
+          echo "Result: green (no baseline available)."
+        fi
+
+        printf "WARNINGS=%s\nERRORS=%s\n" "${warnings_count}" "${errors_count}" > build-metrics.env
+
+        {
+          echo "full-build-base warnings: ${warnings_count}"
+          echo "full-build-base errors: ${errors_count}"
+          if [ -n "${previous_warnings}" ] && [ -n "${previous_errors}" ]; then
+            echo "delta warnings vs last successful ${{ inputs.baseline-branch }} run: ${warnings_delta}"
+            echo "delta errors vs last successful ${{ inputs.baseline-branch }} run: ${errors_delta}"
+          else
+            echo "No previous metrics artifact found on ${{ inputs.baseline-branch }} for comparison."
+          fi
+        } >> "$GITHUB_STEP_SUMMARY"
+
+        if [ "${regression}" = "true" ]; then
+          exit 1
+        fi
+
+    - name: Upload current metrics artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: build-metrics.env
+        retention-days: ${{ inputs.retention-days }}
+        if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,9 +109,23 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
-        run: mvn clean verify --fae
+        # the set command makes the build fail if mvn command fails (no change in behavior)
+        run: |
+          set -o pipefail
+          mvn clean verify --fae 2>&1 | tee full-build-base.log
         env:
           CI_env: GithubAction
+      - name: Analyze and persist full-build-base metrics
+        if: success()
+        continue-on-error: true
+        uses: ./.github/actions/full-build-metrics
+        with:
+          log-file: full-build-base.log
+          artifact-name: full-build-base-metrics
+          baseline-branch: master
+          workflow-file: ci.yml
+          #These are metrics occupy very little space, increasing the retention so they are not lost if nothing is merged to master in a while
+          retention-days: 90
       - name: Upload evomaster.jar
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,14 +120,14 @@ jobs:
           CI_env: GithubAction
       - name: Upload full-build-base log for metrics job
         if: success()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: full-build-base-log-current
           path: full-build-base.log
           retention-days: 1
           if-no-files-found: error
       - name: Upload evomaster.jar
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: evomaster.jar
           path: core/target/evomaster.jar
@@ -159,7 +159,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Download full-build-base log
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: full-build-base-log-current
           path: .
@@ -173,8 +173,6 @@ jobs:
           workflow-file: ci.yml
           #These metrics occupy very little space, increasing the retention so they are not lost if nothing is merged to master in a while
           retention-days: 90
-
-
 
   base-build-mac:
     runs-on: macos-latest
@@ -265,7 +263,7 @@ jobs:
           distribution: ${{env.java-distribution}}
           java-version: ${{env.release-jdk}}
       - name: Download fat jar
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: evomaster.jar
           path: core/target
@@ -273,7 +271,7 @@ jobs:
         shell: bash
         run: bash makeExecutable.sh WINDOWS
       - name: Upload installation file
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: evomaster.msi
           path: release/evomaster-${{env.evomaster-version}}.msi
@@ -291,7 +289,7 @@ jobs:
           distribution: ${{env.java-distribution}}
           java-version: ${{env.release-jdk}}
       - name: Download fat jar
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: evomaster.jar
           path: core/target
@@ -299,7 +297,7 @@ jobs:
         shell: bash
         run: bash makeExecutable.sh OSX
       - name: Upload installation file
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: evomaster.dmg
           path: release/evomaster-${{env.evomaster-version}}.dmg
@@ -317,7 +315,7 @@ jobs:
           distribution: ${{env.java-distribution}}
           java-version: ${{env.release-jdk}}
       - name: Download fat jar
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: evomaster.jar
           path: core/target
@@ -328,7 +326,7 @@ jobs:
         shell: bash
         run: ls -l release
       - name: Upload installation file
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: evomaster.deb
 #          JDK 17 and 21 use different suffixes... doesn't seem configurable :(

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,7 +318,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       - run: npm ci
         working-directory: ./test-utils/test-utils-js
       - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ env:
   # https://github.com/WebFuzzing/EvoMaster/issues/447
   release-jdk: 21
   build-jdk: 17
+  java-distribution: temurin
   retention-days: 5
   debug: false  # put to true if need to debug a specific test
   debugTestName: "GeneRandomizedTest" # replace with test to debug
@@ -74,13 +75,14 @@ jobs:
     needs: setup
     if: needs.setup.outputs.debug == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup JDK ${{env.build-jdk}}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
+          distribution: ${{env.java-distribution}}
           java-version: ${{env.build-jdk}}
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -96,14 +98,15 @@ jobs:
     if: needs.setup.outputs.debug == 'false'
     steps:
       # Checkout code
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # Build/test for JDK
       - name: Setup JDK ${{env.build-jdk}}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
+          distribution: ${{env.java-distribution}}
           java-version: ${{env.build-jdk}}
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -117,14 +120,14 @@ jobs:
           CI_env: GithubAction
       - name: Upload full-build-base log for metrics job
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: full-build-base-log-current
           path: full-build-base.log
           retention-days: 1
           if-no-files-found: error
       - name: Upload evomaster.jar
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: evomaster.jar
           path: core/target/evomaster.jar
@@ -154,9 +157,9 @@ jobs:
     needs: full-build-base
     if: needs.full-build-base.result == 'success'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download full-build-base log
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: full-build-base-log-current
           path: .
@@ -178,13 +181,14 @@ jobs:
     needs: setup
     if: needs.setup.outputs.debug == 'false'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup JDK ${{env.release-jdk}}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
+          distribution: ${{env.java-distribution}}
           java-version: ${{env.release-jdk}}
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -199,13 +203,14 @@ jobs:
     needs: setup
     if: needs.setup.outputs.debug == 'false'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup JDK ${{env.release-jdk}}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
+          distribution: ${{env.java-distribution}}
           java-version: ${{env.release-jdk}}
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -253,13 +258,14 @@ jobs:
     needs: full-build-base
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup JDK ${{env.release-jdk}}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
+          distribution: ${{env.java-distribution}}
           java-version: ${{env.release-jdk}}
       - name: Download fat jar
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: evomaster.jar
           path: core/target
@@ -267,7 +273,7 @@ jobs:
         shell: bash
         run: bash makeExecutable.sh WINDOWS
       - name: Upload installation file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: evomaster.msi
           path: release/evomaster-${{env.evomaster-version}}.msi
@@ -278,13 +284,14 @@ jobs:
     needs: full-build-base
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup JDK ${{env.release-jdk}}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
+          distribution: ${{env.java-distribution}}
           java-version: ${{env.release-jdk}}
       - name: Download fat jar
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: evomaster.jar
           path: core/target
@@ -292,7 +299,7 @@ jobs:
         shell: bash
         run: bash makeExecutable.sh OSX
       - name: Upload installation file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: evomaster.dmg
           path: release/evomaster-${{env.evomaster-version}}.dmg
@@ -303,13 +310,14 @@ jobs:
     needs: full-build-base
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup JDK ${{env.release-jdk}}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
+          distribution: ${{env.java-distribution}}
           java-version: ${{env.release-jdk}}
       - name: Download fat jar
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: evomaster.jar
           path: core/target
@@ -320,7 +328,7 @@ jobs:
         shell: bash
         run: ls -l release
       - name: Upload installation file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: evomaster.deb
 #          JDK 17 and 21 use different suffixes... doesn't seem configurable :(
@@ -333,9 +341,9 @@ jobs:
   test-utils-js:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
       - run: npm ci
@@ -347,9 +355,9 @@ jobs:
   test-utils-py:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Install dependencies
@@ -370,13 +378,14 @@ jobs:
     needs: setup
     if: needs.setup.outputs.debug == 'false'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup JDK ${{env.build-jdk}}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
+          distribution: ${{env.java-distribution}}
           java-version: ${{env.build-jdk}}
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,17 +115,14 @@ jobs:
           mvn clean verify --fae 2>&1 | tee full-build-base.log
         env:
           CI_env: GithubAction
-      - name: Analyze and persist full-build-base metrics
+      - name: Upload full-build-base log for metrics job
         if: success()
-        continue-on-error: true
-        uses: ./.github/actions/full-build-metrics
+        uses: actions/upload-artifact@v4
         with:
-          log-file: full-build-base.log
-          artifact-name: full-build-base-metrics
-          baseline-branch: master
-          workflow-file: ci.yml
-          #These are metrics occupy very little space, increasing the retention so they are not lost if nothing is merged to master in a while
-          retention-days: 90
+          name: full-build-base-log-current
+          path: full-build-base.log
+          retention-days: 1
+          if-no-files-found: error
       - name: Upload evomaster.jar
         uses: actions/upload-artifact@v4
         with:
@@ -151,6 +148,28 @@ jobs:
       - if: github.ref != 'refs/heads/master'
         name: Uploading coverage to CodeCov is done only on 'master' branch builds
         run: echo Skipping upload to CodeCov
+
+  full-build-metrics:
+    runs-on: ubuntu-latest
+    needs: full-build-base
+    if: needs.full-build-base.result == 'success'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download full-build-base log
+        uses: actions/download-artifact@v4
+        with:
+          name: full-build-base-log-current
+          path: .
+      - name: Analyze and persist full-build-base metrics
+        continue-on-error: true
+        uses: ./.github/actions/full-build-metrics
+        with:
+          log-file: full-build-base.log
+          artifact-name: full-build-base-metrics
+          baseline-branch: master
+          workflow-file: ci.yml
+          #These metrics occupy very little space, increasing the retention so they are not lost if nothing is merged to master in a while
+          retention-days: 90
 
 
 


### PR DESCRIPTION
The original intention of this branch / PR was to introduce a new top level job in the build process that would display build metrics (for now just a count of warnings and errors). It will store the count on the environment for 30 days and each build of master will overwrite it, if the current build being executed increases the warnings or error counts the step will show as failed without blocking the build (yellow), if it's equal or less it will show all green. This is "broken window" mechanism to start giving visibility to something developers often oversee. The reviewer of a PR can choose to be strict and require changes to reduce the warning and error count or can let it pass if the merge is important.

As part of this I got carried away and upgraded CI actions to Node 24 compatible versions.

If all test pass please review and give me feedback. I still needs this to be merged to master once to make sure the mechanism works (retrieve the old metrics file and comparing to current build).