### PR TITLE
Hiding Javadoc unnecessary warnings by using quiet mode

### DIFF
--- a/client-java/pom.xml
+++ b/client-java/pom.xml
@@ -66,8 +66,8 @@
     <build>
         <!--
             When we make a release, the client-java must be published on Maven Central.
-            This requires to create jars for sources and javadocs.
-            As the javadocs build might fail, we force its creation at each build,
+            This requires creating jars for sources and Javadocs.
+            As the Javadocs build might fail, we force its creation at each build
             so that any issue can be fixed as soon as it is introduced.
         -->
         <plugins>
@@ -91,6 +91,9 @@
                 <version>3.1.1</version>
                 <configuration>
                     <source>8</source>
+                    <!-- Reducing Javadoc noise, this only leaves the missing Javadoc warnings
+                        and avoids unnecessary warnings about output to HTML -->
+                    <quiet>true</quiet>
                 </configuration>
                 <executions>
                     <execution>

--- a/client-java/pom.xml
+++ b/client-java/pom.xml
@@ -91,9 +91,6 @@
                 <version>3.12.0</version>
                 <configuration>
                     <source>8</source>
-                    <!-- Reducing Javadoc noise, this only leaves the missing Javadoc warnings
-                        and avoids unnecessary warnings about output to HTML -->
-                    <quiet>true</quiet>
                 </configuration>
                 <executions>
                     <execution>

--- a/client-java/pom.xml
+++ b/client-java/pom.xml
@@ -88,7 +88,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.12.0</version>
                 <configuration>
                     <source>8</source>
                     <!-- Reducing Javadoc noise, this only leaves the missing Javadoc warnings


### PR DESCRIPTION
Without quiet mode, Javadoc is very verbose and prints a [WARNING] line for each HTML file it generates. This goes against the initiative of reducing overall warnings as it will generate a new warning for each class introduced. Note that missing Javadoc still generates and prints warnings (check this build), I'm going to pursue another change for that which I will discuss with our not-so-benevolent dictator :D