### PR TITLE
Fix incorrect mapping of StandardGA, MonotonicGA and SteadyStateGA 

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/Main.kt
+++ b/core/src/main/kotlin/org/evomaster/core/Main.kt
@@ -687,6 +687,12 @@ class Main {
                 EMConfig.Algorithm.StandardGA ->
                     Key.get(object : TypeLiteral<StandardGeneticAlgorithm<GraphQLIndividual>>() {})
 
+                EMConfig.Algorithm.MonotonicGA ->
+                    Key.get(object : TypeLiteral<MonotonicGeneticAlgorithm<GraphQLIndividual>>() {})
+
+                EMConfig.Algorithm.SteadyStateGA ->
+                    Key.get(object : TypeLiteral<SteadyStateGeneticAlgorithm<GraphQLIndividual>>() {})
+
                 EMConfig.Algorithm.LIPS ->
                     Key.get(object : TypeLiteral<LIPSAlgorithm<GraphQLIndividual>>() {})
 
@@ -728,6 +734,15 @@ class Main {
                 EMConfig.Algorithm.MOSA ->
                     Key.get(object : TypeLiteral<MosaAlgorithm<RPCIndividual>>() {})
 
+                EMConfig.Algorithm.StandardGA ->
+                    Key.get(object : TypeLiteral<StandardGeneticAlgorithm<RPCIndividual>>() {})
+
+                EMConfig.Algorithm.MonotonicGA ->
+                    Key.get(object : TypeLiteral<MonotonicGeneticAlgorithm<RPCIndividual>>() {})
+
+                EMConfig.Algorithm.SteadyStateGA ->
+                    Key.get(object : TypeLiteral<SteadyStateGeneticAlgorithm<RPCIndividual>>() {})
+
                 EMConfig.Algorithm.RW ->
                     Key.get(object : TypeLiteral<RandomWalkAlgorithm<RPCIndividual>>() {})
 
@@ -736,6 +751,7 @@ class Main {
 
                 EMConfig.Algorithm.MuPlusLambdaEA ->
                     Key.get(object : TypeLiteral<MuPlusLambdaEvolutionaryAlgorithm<RPCIndividual>>() {})
+
                 EMConfig.Algorithm.MuLambdaEA ->
                     Key.get(object : TypeLiteral<MuLambdaEvolutionaryAlgorithm<RPCIndividual>>(){})
 
@@ -769,6 +785,15 @@ class Main {
 
                 EMConfig.Algorithm.MOSA ->
                     Key.get(object : TypeLiteral<MosaAlgorithm<WebIndividual>>() {})
+
+                EMConfig.Algorithm.StandardGA ->
+                    Key.get(object : TypeLiteral<StandardGeneticAlgorithm<WebIndividual>>() {})
+
+                EMConfig.Algorithm.MonotonicGA ->
+                    Key.get(object : TypeLiteral<MonotonicGeneticAlgorithm<WebIndividual>>() {})
+
+                EMConfig.Algorithm.SteadyStateGA ->
+                    Key.get(object : TypeLiteral<SteadyStateGeneticAlgorithm<WebIndividual>>() {})
 
                 EMConfig.Algorithm.RW ->
                     Key.get(object : TypeLiteral<RandomWalkAlgorithm<WebIndividual>>() {})
@@ -814,13 +839,13 @@ class Main {
                     Key.get(object : TypeLiteral<MosaAlgorithm<RestIndividual>>() {})
 
                 EMConfig.Algorithm.StandardGA ->
-                    Key.get(object : TypeLiteral<MosaAlgorithm<RestIndividual>>() {})
+                    Key.get(object : TypeLiteral<StandardGeneticAlgorithm<RestIndividual>>() {})
 
                 EMConfig.Algorithm.MonotonicGA ->
-                    Key.get(object : TypeLiteral<MosaAlgorithm<RestIndividual>>() {})
+                    Key.get(object : TypeLiteral<MonotonicGeneticAlgorithm<RestIndividual>>() {})
 
                 EMConfig.Algorithm.SteadyStateGA ->
-                    Key.get(object : TypeLiteral<MosaAlgorithm<RestIndividual>>() {})
+                    Key.get(object : TypeLiteral<SteadyStateGeneticAlgorithm<RestIndividual>>() {})
 
                 EMConfig.Algorithm.RW ->
                     Key.get(object : TypeLiteral<RandomWalkAlgorithm<RestIndividual>>() {})

--- a/core/src/main/kotlin/org/evomaster/core/Main.kt
+++ b/core/src/main/kotlin/org/evomaster/core/Main.kt
@@ -688,12 +688,14 @@ class Main {
                     Key.get(object : TypeLiteral<StandardGeneticAlgorithm<GraphQLIndividual>>() {})
 
                 EMConfig.Algorithm.LIPS ->
-                    Key.get(object : TypeLiteral<org.evomaster.core.search.algorithms.LIPSAlgorithm<GraphQLIndividual>>() {})
+                    Key.get(object : TypeLiteral<LIPSAlgorithm<GraphQLIndividual>>() {})
+
                 EMConfig.Algorithm.MuPlusLambdaEA ->
                     Key.get(object : TypeLiteral<MuPlusLambdaEvolutionaryAlgorithm<GraphQLIndividual>>() {})
 
                 EMConfig.Algorithm.MuLambdaEA ->
-                    Key.get(object : TypeLiteral<org.evomaster.core.search.algorithms.MuLambdaEvolutionaryAlgorithm<GraphQLIndividual>>(){})
+                    Key.get(object : TypeLiteral<MuLambdaEvolutionaryAlgorithm<GraphQLIndividual>>(){})
+
                 EMConfig.Algorithm.BreederGA ->
                     Key.get(object : TypeLiteral<BreederGeneticAlgorithm<GraphQLIndividual>>() {})
 
@@ -728,13 +730,14 @@ class Main {
 
                 EMConfig.Algorithm.RW ->
                     Key.get(object : TypeLiteral<RandomWalkAlgorithm<RPCIndividual>>() {})
+
                 EMConfig.Algorithm.LIPS ->
-                    Key.get(object : TypeLiteral<org.evomaster.core.search.algorithms.LIPSAlgorithm<RPCIndividual>>() {})
+                    Key.get(object : TypeLiteral<LIPSAlgorithm<RPCIndividual>>() {})
 
                 EMConfig.Algorithm.MuPlusLambdaEA ->
                     Key.get(object : TypeLiteral<MuPlusLambdaEvolutionaryAlgorithm<RPCIndividual>>() {})
                 EMConfig.Algorithm.MuLambdaEA ->
-                    Key.get(object : TypeLiteral<org.evomaster.core.search.algorithms.MuLambdaEvolutionaryAlgorithm<RPCIndividual>>(){})
+                    Key.get(object : TypeLiteral<MuLambdaEvolutionaryAlgorithm<RPCIndividual>>(){})
 
                 EMConfig.Algorithm.BreederGA ->
                     Key.get(object : TypeLiteral<BreederGeneticAlgorithm<RPCIndividual>>() {})
@@ -744,6 +747,7 @@ class Main {
 
                 EMConfig.Algorithm.OnePlusLambdaLambdaGA ->
                     Key.get(object : TypeLiteral<OnePlusLambdaLambdaGeneticAlgorithm<RPCIndividual>>() {})
+
                 else -> throw IllegalStateException("Unrecognized algorithm ${config.algorithm}")
             }
         }
@@ -768,13 +772,15 @@ class Main {
 
                 EMConfig.Algorithm.RW ->
                     Key.get(object : TypeLiteral<RandomWalkAlgorithm<WebIndividual>>() {})
+
                 EMConfig.Algorithm.LIPS ->
-                    Key.get(object : TypeLiteral<org.evomaster.core.search.algorithms.LIPSAlgorithm<WebIndividual>>() {})
+                    Key.get(object : TypeLiteral<LIPSAlgorithm<WebIndividual>>() {})
 
                 EMConfig.Algorithm.MuPlusLambdaEA ->
                     Key.get(object : TypeLiteral<MuPlusLambdaEvolutionaryAlgorithm<WebIndividual>>() {})
+
                 EMConfig.Algorithm.MuLambdaEA ->
-                    Key.get(object : TypeLiteral<org.evomaster.core.search.algorithms.MuLambdaEvolutionaryAlgorithm<WebIndividual>>(){})
+                    Key.get(object : TypeLiteral<MuLambdaEvolutionaryAlgorithm<WebIndividual>>(){})
 
                 EMConfig.Algorithm.BreederGA ->
                     Key.get(object : TypeLiteral<BreederGeneticAlgorithm<WebIndividual>>() {})
@@ -784,6 +790,7 @@ class Main {
 
                 EMConfig.Algorithm.OnePlusLambdaLambdaGA ->
                     Key.get(object : TypeLiteral<OnePlusLambdaLambdaGeneticAlgorithm<WebIndividual>>() {})
+
                 else -> throw IllegalStateException("Unrecognized algorithm ${config.algorithm}")
             }
         }
@@ -817,12 +824,15 @@ class Main {
 
                 EMConfig.Algorithm.RW ->
                     Key.get(object : TypeLiteral<RandomWalkAlgorithm<RestIndividual>>() {})
+
                 EMConfig.Algorithm.LIPS ->
-                    Key.get(object : TypeLiteral<org.evomaster.core.search.algorithms.LIPSAlgorithm<RestIndividual>>() {})
+                    Key.get(object : TypeLiteral<LIPSAlgorithm<RestIndividual>>() {})
+
                 EMConfig.Algorithm.MuPlusLambdaEA ->
                     Key.get(object : TypeLiteral<MuPlusLambdaEvolutionaryAlgorithm<RestIndividual>>() {})
+
                 EMConfig.Algorithm.MuLambdaEA ->
-                    Key.get(object : TypeLiteral<org.evomaster.core.search.algorithms.MuLambdaEvolutionaryAlgorithm<RestIndividual>>(){})
+                    Key.get(object : TypeLiteral<MuLambdaEvolutionaryAlgorithm<RestIndividual>>(){})
 
                 EMConfig.Algorithm.BreederGA ->
                     Key.get(object : TypeLiteral<BreederGeneticAlgorithm<RestIndividual>>() {})


### PR DESCRIPTION
### Summary
This pull request introduces support for `MonotonicGA` and `SteadyStateGA` in algorithm type mappings. Additionally, redundant package prefixes in the mappings have been removed for better readability.

### Changes
- Bugfix `StandardGA`, `MonotonicGA` and `SteadyStateGA` were not being chosen in Main.
- Refactored code to eliminate redundant package prefixes in the mappings.
