### PR TITLE
Fix enumGene's getValueAsPrintableString in xml mode

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/search/gene/collection/EnumGene.kt
+++ b/core/src/main/kotlin/org/evomaster/core/search/gene/collection/EnumGene.kt
@@ -225,7 +225,7 @@ class EnumGene<T : Comparable<T>>(
     override fun getValueAsPrintableString(previousGenes: List<Gene>, mode: GeneUtils.EscapeMode?, targetFormat: OutputFormat?, extraCheck: Boolean): String {
 
         val res = values[index]
-        if (res is String && !treatAsNotString) {
+        if (res is String && !treatAsNotString && mode != GeneUtils.EscapeMode.XML) {
             return "\"$res\""
         } else {
             return res.toString()

--- a/core/src/main/kotlin/org/evomaster/core/search/gene/collection/EnumGene.kt
+++ b/core/src/main/kotlin/org/evomaster/core/search/gene/collection/EnumGene.kt
@@ -225,6 +225,9 @@ class EnumGene<T : Comparable<T>>(
     override fun getValueAsPrintableString(previousGenes: List<Gene>, mode: GeneUtils.EscapeMode?, targetFormat: OutputFormat?, extraCheck: Boolean): String {
 
         val res = values[index]
+        // In XML mode, enum string values are emitted as tag text content (e.g. <path>VALUE</path>).
+        // Unlike JSON, XML does not use quotes to delimit string values — the tags are the delimiters.
+        // Adding quotes here would include them as literal characters in the XML output.
         if (res is String && !treatAsNotString && mode != GeneUtils.EscapeMode.XML) {
             return "\"$res\""
         } else {

--- a/core/src/test/kotlin/org/evomaster/core/search/gene/EnumGeneTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/search/gene/EnumGeneTest.kt
@@ -1,6 +1,7 @@
 package org.evomaster.core.search.gene
 
 import org.evomaster.core.search.gene.collection.EnumGene
+import org.evomaster.core.search.gene.utils.GeneUtils
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -12,4 +13,49 @@ class EnumGeneTest {
         val enumGene = EnumGene("value", data)
         assertEquals(0, enumGene.values.size)
     }
+
+    // --- String enum: JSON vs XML ---
+
+    @Test
+    fun testStringEnum_jsonMode_wrapsInQuotes() {
+        val gene = EnumGene("status", listOf("ACTIVE", "INACTIVE"))
+        gene.index = 0
+        val result = gene.getValueAsPrintableString(mode = null)
+        assertEquals("\"ACTIVE\"", result)
+    }
+
+    @Test
+    fun testStringEnum_xmlMode_noQuotes() {
+        val gene = EnumGene("status", listOf("ACTIVE", "INACTIVE"))
+        gene.index = 0
+        val result = gene.getValueAsPrintableString(mode = GeneUtils.EscapeMode.XML)
+        assertEquals("ACTIVE", result)
+    }
+
+    @Test
+    fun testStringEnum_xmlMode_secondValue_noQuotes() {
+        val gene = EnumGene("status", listOf("ACTIVE", "INACTIVE"))
+        gene.index = 1
+        val result = gene.getValueAsPrintableString(mode = GeneUtils.EscapeMode.XML)
+        assertEquals("INACTIVE", result)
+    }
+
+    // --- Non-string enum: XML mode should work as before ---
+
+    @Test
+    fun testIntEnum_xmlMode_noQuotes() {
+        val gene = EnumGene("priority", listOf(1, 2, 3))
+        gene.index = 0
+        val result = gene.getValueAsPrintableString(mode = GeneUtils.EscapeMode.XML)
+        assertEquals("1", result)
+    }
+
+    @Test
+    fun testIntEnum_nullMode_noQuotes() {
+        val gene = EnumGene("priority", listOf(1, 2, 3))
+        gene.index = 2
+        val result = gene.getValueAsPrintableString(mode = null)
+        assertEquals("3", result)
+    }
+
 }


### PR DESCRIPTION
We add this condition so, in xml mode, it prints without simple quoting.