### PR TITLE
Add MCP blackbox sampler — Phases 1–4

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/problem/mcp/McpAction.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/mcp/McpAction.kt
@@ -1,0 +1,18 @@
+package org.evomaster.core.problem.mcp
+
+import org.evomaster.core.problem.api.param.Param
+import org.evomaster.core.search.action.MainAction
+import org.evomaster.core.search.gene.Gene
+
+abstract class McpAction(
+    val id: String,
+    parameters: MutableList<Param>
+) : MainAction(false, parameters) {
+
+    val parameters: List<Param>
+        get() = children as List<Param>
+
+    override fun getName(): String = id
+
+    override fun seeTopGenes(): List<Gene> = parameters.flatMap { it.seeGenes() }
+}

--- a/core/src/main/kotlin/org/evomaster/core/problem/mcp/McpCallResult.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/mcp/McpCallResult.kt
@@ -1,0 +1,26 @@
+package org.evomaster.core.problem.mcp
+
+import org.evomaster.core.search.action.ActionResult
+
+class McpCallResult : ActionResult {
+
+    companion object {
+        const val IS_ERROR = "IS_ERROR"
+    }
+
+    constructor(sourceLocalId: String) : super(sourceLocalId)
+
+    /**
+     * Copy constructor. Delegates to the [ActionResult] copy constructor
+     * which propagates [stopping], [deathSentence], and the results map.
+     */
+    private constructor(other: McpCallResult) : super(other)
+
+    override fun copy(): McpCallResult = McpCallResult(this)
+
+    fun setIsError(isError: Boolean) {
+        addResultValue(IS_ERROR, isError.toString())
+    }
+
+    fun getIsError(): Boolean = getResultValue(IS_ERROR)?.toBoolean() ?: false
+}

--- a/core/src/main/kotlin/org/evomaster/core/problem/mcp/McpIndividual.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/mcp/McpIndividual.kt
@@ -1,0 +1,48 @@
+package org.evomaster.core.problem.mcp
+
+import org.evomaster.core.problem.api.ApiWsIndividual
+import org.evomaster.core.problem.enterprise.EnterpriseChildTypeVerifier
+import org.evomaster.core.problem.enterprise.EnterpriseIndividual.Companion.getEnterpriseTopGroups
+import org.evomaster.core.problem.enterprise.SampleType
+import org.evomaster.core.search.GroupsOfChildren
+import org.evomaster.core.search.Individual
+import org.evomaster.core.search.StructuralElement
+import org.evomaster.core.search.action.ActionComponent
+
+class McpIndividual(
+    sampleType: SampleType,
+    allActions: MutableList<out ActionComponent>,
+    mainSize: Int = allActions.size,
+    sqlSize: Int = 0,
+    mongoSize: Int = 0,
+    groups: GroupsOfChildren<StructuralElement> =
+        getEnterpriseTopGroups(allActions, mainSize, sqlSize, mongoSize, 0, 0, 0, 0)
+) : ApiWsIndividual(
+    sampleType = sampleType,
+    children = allActions,
+    childTypeVerifier = EnterpriseChildTypeVerifier(McpAction::class.java),
+    groups = groups
+) {
+
+    override fun copyContent(): Individual {
+        return McpIndividual(
+            sampleType,
+            children.map { it.copy() }.toMutableList() as MutableList<ActionComponent>,
+            mainSize = groupsView()!!.sizeOfGroup(GroupsOfChildren.MAIN),
+            sqlSize = groupsView()!!.sizeOfGroup(GroupsOfChildren.INITIALIZATION_SQL),
+            mongoSize = groupsView()!!.sizeOfGroup(GroupsOfChildren.INITIALIZATION_MONGO)
+        )
+    }
+
+    fun addMcpAction(relativePosition: Int = -1, action: McpAction) {
+        addMainActionInEmptyEnterpriseGroup(relativePosition, action)
+    }
+
+    fun removeMcpActionAt(relativePosition: Int) {
+        killChildByIndex(relativePosition)
+    }
+
+    override fun seeMainExecutableActions(): List<McpAction> {
+        return super.seeMainExecutableActions() as List<McpAction>
+    }
+}

--- a/core/src/main/kotlin/org/evomaster/core/problem/mcp/McpInputParam.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/mcp/McpInputParam.kt
@@ -1,0 +1,8 @@
+package org.evomaster.core.problem.mcp
+
+import org.evomaster.core.problem.api.param.Param
+import org.evomaster.core.search.gene.Gene
+
+class McpInputParam(name: String, gene: Gene) : Param(name, gene) {
+    override fun copyContent(): Param = McpInputParam(name, gene.copy())
+}

--- a/core/src/main/kotlin/org/evomaster/core/problem/mcp/McpResourceReadAction.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/mcp/McpResourceReadAction.kt
@@ -1,0 +1,16 @@
+package org.evomaster.core.problem.mcp
+
+import org.evomaster.core.search.action.Action
+import org.evomaster.core.search.gene.string.StringGene
+
+class McpResourceReadAction(
+    val uri: StringGene,
+    val isTemplate: Boolean = false
+) : McpAction(
+    id = "resource:${uri.value}",
+    parameters = mutableListOf(McpUriParam("uri", uri))
+) {
+    override fun copyContent(): Action {
+        return McpResourceReadAction(uri.copy() as StringGene, isTemplate)
+    }
+}

--- a/core/src/main/kotlin/org/evomaster/core/problem/mcp/McpToolCallAction.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/mcp/McpToolCallAction.kt
@@ -1,0 +1,17 @@
+package org.evomaster.core.problem.mcp
+
+import org.evomaster.core.search.action.Action
+import org.evomaster.core.search.gene.ObjectGene
+
+class McpToolCallAction(
+    val toolName: String,
+    val inputSchema: ObjectGene,
+    val description: String = ""
+) : McpAction(
+    id = "tool:$toolName",
+    parameters = mutableListOf(McpInputParam("input", inputSchema))
+) {
+    override fun copyContent(): Action {
+        return McpToolCallAction(toolName, inputSchema.copy() as ObjectGene, description)
+    }
+}

--- a/core/src/main/kotlin/org/evomaster/core/problem/mcp/McpUriParam.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/mcp/McpUriParam.kt
@@ -1,0 +1,8 @@
+package org.evomaster.core.problem.mcp
+
+import org.evomaster.core.problem.api.param.Param
+import org.evomaster.core.search.gene.Gene
+
+class McpUriParam(name: String, gene: Gene) : Param(name, gene) {
+    override fun copyContent(): Param = McpUriParam(name, gene.copy())
+}

--- a/core/src/main/kotlin/org/evomaster/core/problem/mcp/client/HttpMcpClient.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/mcp/client/HttpMcpClient.kt
@@ -1,0 +1,142 @@
+package org.evomaster.core.problem.mcp.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.concurrent.atomic.AtomicInteger
+
+class HttpMcpClient(private val baseUrl: String) : McpClient {
+
+    private val mapper: ObjectMapper = ObjectMapper()
+    private val idCounter = AtomicInteger(1)
+
+    private fun nextId() = idCounter.getAndIncrement()
+
+    private fun post(method: String, params: Map<String, Any?> = emptyMap()): Map<String, Any?> {
+        val body = mapper.writeValueAsString(
+            mapOf(
+                "jsonrpc" to "2.0",
+                "method" to method,
+                "params" to params,
+                "id" to nextId()
+            )
+        )
+        val url = URL(baseUrl)
+        val conn = url.openConnection() as HttpURLConnection
+        conn.requestMethod = "POST"
+        conn.setRequestProperty("Content-Type", "application/json")
+        conn.setRequestProperty("Accept", "application/json")
+        conn.doOutput = true
+        conn.connectTimeout = 10_000
+        conn.readTimeout = 30_000
+        conn.outputStream.use { it.write(body.toByteArray(Charsets.UTF_8)) }
+        val responseBody = conn.inputStream.use { it.readBytes().toString(Charsets.UTF_8) }
+        @Suppress("UNCHECKED_CAST")
+        return mapper.readValue(responseBody, Map::class.java) as Map<String, Any?>
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun listTools(): List<McpToolDefinition> {
+        val tools = mutableListOf<McpToolDefinition>()
+        var cursor: String? = null
+        do {
+            val params: Map<String, Any?> = if (cursor != null) mapOf("cursor" to cursor) else emptyMap()
+            val response = post("tools/list", params)
+            val result = response["result"] as? Map<String, Any?> ?: break
+            val items = result["tools"] as? List<*> ?: emptyList<Any>()
+            items.filterIsInstance<Map<String, Any?>>().forEach { t ->
+                tools.add(
+                    McpToolDefinition(
+                        name = t["name"] as? String ?: "",
+                        description = t["description"] as? String ?: "",
+                        inputSchema = t["inputSchema"] as? Map<String, Any?> ?: emptyMap()
+                    )
+                )
+            }
+            cursor = result["nextCursor"] as? String
+        } while (cursor != null)
+        return tools
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun listResources(): List<McpResourceDefinition> {
+        val resources = mutableListOf<McpResourceDefinition>()
+        var cursor: String? = null
+        do {
+            val params: Map<String, Any?> = if (cursor != null) mapOf("cursor" to cursor) else emptyMap()
+            val response = post("resources/list", params)
+            val result = response["result"] as? Map<String, Any?> ?: break
+            val items = result["resources"] as? List<*> ?: emptyList<Any>()
+            items.filterIsInstance<Map<String, Any?>>().forEach { r ->
+                resources.add(
+                    McpResourceDefinition(
+                        uri = r["uri"] as? String ?: "",
+                        name = r["name"] as? String ?: "",
+                        description = r["description"] as? String ?: "",
+                        mimeType = r["mimeType"] as? String
+                    )
+                )
+            }
+            cursor = result["nextCursor"] as? String
+        } while (cursor != null)
+        return resources
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun listResourceTemplates(): List<McpResourceTemplate> {
+        val templates = mutableListOf<McpResourceTemplate>()
+        var cursor: String? = null
+        do {
+            val params: Map<String, Any?> = if (cursor != null) mapOf("cursor" to cursor) else emptyMap()
+            val response = post("resources/templates/list", params)
+            val result = response["result"] as? Map<String, Any?> ?: break
+            val items = result["resourceTemplates"] as? List<*> ?: emptyList<Any>()
+            items.filterIsInstance<Map<String, Any?>>().forEach { t ->
+                templates.add(
+                    McpResourceTemplate(
+                        uriTemplate = t["uriTemplate"] as? String ?: "",
+                        name = t["name"] as? String ?: "",
+                        description = t["description"] as? String ?: ""
+                    )
+                )
+            }
+            cursor = result["nextCursor"] as? String
+        } while (cursor != null)
+        return templates
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun callTool(name: String, arguments: Map<String, Any?>): McpToolResult {
+        val response = post("tools/call", mapOf("name" to name, "arguments" to arguments))
+        val result = response["result"] as? Map<String, Any?> ?: return McpToolResult(isError = true)
+        val rawContent = result["content"] as? List<*> ?: emptyList<Any>()
+        val content = rawContent.filterIsInstance<Map<String, Any?>>().map { c ->
+            McpContent(
+                type = c["type"] as? String ?: "text",
+                text = c["text"] as? String,
+                uri = c["uri"] as? String,
+                mimeType = c["mimeType"] as? String
+            )
+        }
+        return McpToolResult(
+            content = content,
+            isError = result["isError"] as? Boolean ?: false
+        )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun readResource(uri: String): McpResourceResult {
+        val response = post("resources/read", mapOf("uri" to uri))
+        val result = response["result"] as? Map<String, Any?> ?: return McpResourceResult()
+        val rawContents = result["contents"] as? List<*> ?: emptyList<Any>()
+        val contents = rawContents.filterIsInstance<Map<String, Any?>>().map { c ->
+            McpContent(
+                type = c["type"] as? String ?: "text",
+                text = c["text"] as? String,
+                uri = c["uri"] as? String,
+                mimeType = c["mimeType"] as? String
+            )
+        }
+        return McpResourceResult(contents = contents)
+    }
+}

--- a/core/src/main/kotlin/org/evomaster/core/problem/mcp/client/McpClient.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/mcp/client/McpClient.kt
@@ -1,0 +1,9 @@
+package org.evomaster.core.problem.mcp.client
+
+interface McpClient {
+    fun listTools(): List<McpToolDefinition>
+    fun listResources(): List<McpResourceDefinition>
+    fun listResourceTemplates(): List<McpResourceTemplate>
+    fun callTool(name: String, arguments: Map<String, Any?>): McpToolResult
+    fun readResource(uri: String): McpResourceResult
+}

--- a/core/src/main/kotlin/org/evomaster/core/problem/mcp/client/McpDTOs.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/mcp/client/McpDTOs.kt
@@ -1,0 +1,36 @@
+package org.evomaster.core.problem.mcp.client
+
+data class McpToolDefinition(
+    val name: String,
+    val description: String = "",
+    val inputSchema: Map<String, Any?> = emptyMap()
+)
+
+data class McpResourceDefinition(
+    val uri: String,
+    val name: String = "",
+    val description: String = "",
+    val mimeType: String? = null
+)
+
+data class McpResourceTemplate(
+    val uriTemplate: String,
+    val name: String = "",
+    val description: String = ""
+)
+
+data class McpToolResult(
+    val content: List<McpContent> = emptyList(),
+    val isError: Boolean = false
+)
+
+data class McpResourceResult(
+    val contents: List<McpContent> = emptyList()
+)
+
+data class McpContent(
+    val type: String,
+    val text: String? = null,
+    val uri: String? = null,
+    val mimeType: String? = null
+)

--- a/core/src/main/kotlin/org/evomaster/core/problem/mcp/service/McpBlackBoxFitness.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/mcp/service/McpBlackBoxFitness.kt
@@ -1,0 +1,128 @@
+package org.evomaster.core.problem.mcp.service
+
+import com.google.inject.Inject
+import org.evomaster.core.problem.mcp.McpCallResult
+import org.evomaster.core.problem.mcp.McpIndividual
+import org.evomaster.core.problem.mcp.McpResourceReadAction
+import org.evomaster.core.problem.mcp.McpToolCallAction
+import org.evomaster.core.search.EvaluatedIndividual
+import org.evomaster.core.search.FitnessValue
+import org.evomaster.core.search.action.ActionResult
+import org.evomaster.core.search.gene.BooleanGene
+import org.evomaster.core.search.gene.Gene
+import org.evomaster.core.search.gene.ObjectGene
+import org.evomaster.core.search.gene.collection.ArrayGene
+import org.evomaster.core.search.gene.numeric.NumberGene
+import org.evomaster.core.search.gene.string.StringGene
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+/**
+ * Blackbox fitness function for MCP servers.
+ *
+ * Executes each action in an [McpIndividual] sequentially via the [McpSampler]'s client
+ * and scores coverage targets based on observable protocol signals (isError flag,
+ * successful reads). Mirrors [GraphQLBlackBoxFitness] in structure.
+ */
+class McpBlackBoxFitness : McpFitness() {
+
+    companion object {
+        private val log: Logger = LoggerFactory.getLogger(McpBlackBoxFitness::class.java)
+    }
+
+    @Inject
+    private lateinit var sampler: McpSampler
+
+    override fun doCalculateCoverage(
+        individual: McpIndividual,
+        targets: Set<Int>,
+        allTargets: Boolean,
+        fullyCovered: Boolean,
+        descriptiveIds: Boolean,
+    ): EvaluatedIndividual<McpIndividual>? {
+
+        val fv = FitnessValue(individual.size().toDouble())
+        val actionResults: MutableList<ActionResult> = mutableListOf()
+        val client = sampler.getMcpClient()
+
+        val actions = individual.seeMainExecutableActions()
+
+        for (i in actions.indices) {
+            val action = actions[i]
+            val result = McpCallResult(action.getLocalId())
+            actionResults.add(result)
+
+            try {
+                when (action) {
+                    is McpToolCallAction -> {
+                        val args = geneToMap(action.inputSchema)
+                        val toolResult = client.callTool(action.toolName, args)
+
+                        result.setIsError(toolResult.isError)
+                        result.stopping = false
+
+                        val targetId = idMapper.handleLocalTarget("tool:${action.toolName}")
+                        val score = if (!toolResult.isError) 1.0 else 0.5
+                        fv.updateTarget(targetId, score, i)
+                    }
+
+                    is McpResourceReadAction -> {
+                        val resourceResult = client.readResource(action.uri.value)
+                        result.setIsError(false)
+                        result.stopping = false
+
+                        val targetId = idMapper.handleLocalTarget("resource:${action.id}")
+                        // A successful read (even empty contents) scores 1.0
+                        fv.updateTarget(targetId, 1.0, i)
+                    }
+
+                    else -> {
+                        result.stopping = false
+                    }
+                }
+            } catch (e: Exception) {
+                log.warn("Exception evaluating MCP action ${action.id}: ${e.message}")
+                result.setIsError(true)
+                result.stopping = true
+                break
+            }
+        }
+
+        return EvaluatedIndividual(
+            fv,
+            individual.copy() as McpIndividual,
+            actionResults,
+            trackOperator = individual.trackOperator,
+            index = time.evaluatedIndividuals,
+            config = config
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Convert an [ObjectGene] to a [Map] of argument values suitable for passing
+     * to [McpClient.callTool]. Uses typed gene values when available, falling
+     * back to printable string representation for complex types.
+     */
+    private fun geneToMap(gene: ObjectGene): Map<String, Any?> {
+        val map = mutableMapOf<String, Any?>()
+        for (field in gene.fields) {
+            map[field.name] = extractGeneValue(field)
+        }
+        return map
+    }
+
+    private fun extractGeneValue(gene: Gene): Any? {
+        return when (gene) {
+            is StringGene -> gene.value
+            is BooleanGene -> gene.value
+            is NumberGene<*> -> gene.value
+            is ObjectGene -> geneToMap(gene)
+            is ArrayGene<*> -> gene.getViewOfElements().map { extractGeneValue(it) }
+            else -> gene.getValueAsPrintableString(listOf(), null, null, false)
+        }
+    }
+}

--- a/core/src/main/kotlin/org/evomaster/core/problem/mcp/service/McpBlackBoxModule.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/mcp/service/McpBlackBoxModule.kt
@@ -1,0 +1,82 @@
+package org.evomaster.core.problem.mcp.service
+
+import com.google.inject.AbstractModule
+import com.google.inject.TypeLiteral
+import org.evomaster.core.problem.enterprise.service.EnterpriseSampler
+import org.evomaster.core.problem.mcp.McpIndividual
+import org.evomaster.core.remote.service.RemoteController
+import org.evomaster.core.remote.service.RemoteControllerImplementation
+import org.evomaster.core.search.service.Archive
+import org.evomaster.core.search.service.FitnessFunction
+import org.evomaster.core.search.service.FlakinessDetector
+import org.evomaster.core.search.service.Minimizer
+import org.evomaster.core.search.service.Sampler
+
+/**
+ * Guice module wiring the MCP blackbox testing components.
+ *
+ * Mirrors [GraphQLBlackBoxModule] but for the MCP problem domain.
+ * No TestCaseWriter is bound yet (MCP test output not implemented in Phase 4).
+ */
+class McpBlackBoxModule(
+    val usingRemoteController: Boolean
+) : AbstractModule() {
+
+    override fun configure() {
+
+        bind(object : TypeLiteral<EnterpriseSampler<McpIndividual>>() {})
+            .to(McpSampler::class.java)
+            .asEagerSingleton()
+
+        bind(object : TypeLiteral<Sampler<McpIndividual>>() {})
+            .to(McpSampler::class.java)
+            .asEagerSingleton()
+
+        bind(object : TypeLiteral<Sampler<*>>() {})
+            .to(McpSampler::class.java)
+            .asEagerSingleton()
+
+        bind(McpSampler::class.java)
+            .asEagerSingleton()
+
+        bind(object : TypeLiteral<FitnessFunction<McpIndividual>>() {})
+            .to(McpBlackBoxFitness::class.java)
+            .asEagerSingleton()
+
+        bind(object : TypeLiteral<FitnessFunction<*>>() {})
+            .to(McpBlackBoxFitness::class.java)
+            .asEagerSingleton()
+
+        bind(object : TypeLiteral<Archive<McpIndividual>>() {})
+            .asEagerSingleton()
+
+        bind(object : TypeLiteral<Archive<*>>() {})
+            .to(object : TypeLiteral<Archive<McpIndividual>>() {})
+
+        bind(Archive::class.java)
+            .to(object : TypeLiteral<Archive<McpIndividual>>() {})
+
+        bind(object : TypeLiteral<Minimizer<McpIndividual>>() {})
+            .asEagerSingleton()
+
+        bind(object : TypeLiteral<Minimizer<*>>() {})
+            .to(object : TypeLiteral<Minimizer<McpIndividual>>() {})
+            .asEagerSingleton()
+
+        bind(object : TypeLiteral<FlakinessDetector<McpIndividual>>() {})
+            .asEagerSingleton()
+
+        bind(object : TypeLiteral<FlakinessDetector<*>>() {})
+            .to(object : TypeLiteral<FlakinessDetector<McpIndividual>>() {})
+            .asEagerSingleton()
+
+        if (usingRemoteController) {
+            bind(RemoteController::class.java)
+                .to(RemoteControllerImplementation::class.java)
+                .asEagerSingleton()
+        }
+
+        // TestCaseWriter for MCP is not yet implemented.
+        // When MCP test output is added, bind TestCaseWriter to an McpTestCaseWriter here.
+    }
+}

--- a/core/src/main/kotlin/org/evomaster/core/problem/mcp/service/McpFitness.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/mcp/service/McpFitness.kt
@@ -1,0 +1,11 @@
+package org.evomaster.core.problem.mcp.service
+
+import org.evomaster.core.problem.mcp.McpIndividual
+import org.evomaster.core.search.service.FitnessFunction
+
+/**
+ * Abstract fitness function base for MCP testing.
+ * Concrete subclasses provide the actual coverage calculation strategy
+ * (blackbox, whitebox, etc.).
+ */
+abstract class McpFitness : FitnessFunction<McpIndividual>()

--- a/core/src/main/kotlin/org/evomaster/core/problem/mcp/service/McpSampler.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/mcp/service/McpSampler.kt
@@ -1,0 +1,210 @@
+package org.evomaster.core.problem.mcp.service
+
+import org.evomaster.client.java.controller.api.dto.SutInfoDto
+import org.evomaster.core.problem.api.service.ApiWsSampler
+import org.evomaster.core.problem.enterprise.EnterpriseActionGroup
+import org.evomaster.core.problem.enterprise.SampleType
+import org.evomaster.core.problem.mcp.McpAction
+import org.evomaster.core.problem.mcp.McpIndividual
+import org.evomaster.core.problem.mcp.McpResourceReadAction
+import org.evomaster.core.problem.mcp.McpToolCallAction
+import org.evomaster.core.problem.mcp.client.HttpMcpClient
+import org.evomaster.core.search.action.ActionComponent
+import org.evomaster.core.search.gene.Gene
+import org.evomaster.core.search.gene.ObjectGene
+import org.evomaster.core.search.gene.collection.ArrayGene
+import org.evomaster.core.search.gene.numeric.IntegerGene
+import org.evomaster.core.search.gene.BooleanGene
+import org.evomaster.core.search.gene.string.StringGene
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import javax.annotation.PostConstruct
+
+/**
+ * Sampler for MCP blackbox testing.
+ *
+ * On initialization, connects to the MCP server at [config.bbTargetUrl], discovers
+ * tools and resources, and builds an action cluster. Follows the pattern of GraphQLSampler
+ * (blackbox init) and RPCSampler (dual cluster + adHoc individuals).
+ */
+class McpSampler : ApiWsSampler<McpIndividual>() {
+
+    companion object {
+        private val log: Logger = LoggerFactory.getLogger(McpSampler::class.java)
+    }
+
+    private lateinit var mcpClient: HttpMcpClient
+
+    /** Actions for MCP tool calls, keyed by "tool:<toolName>" */
+    private val toolActionCluster: MutableMap<String, McpToolCallAction> = mutableMapOf()
+
+    /** Actions for MCP resource reads, keyed by "resource:<uri>" or template key */
+    private val resourceActionCluster: MutableMap<String, McpResourceReadAction> = mutableMapOf()
+
+    /** Pre-built single-call individuals, drained first in smartSample() */
+    private val adHocInitialIndividuals: MutableList<McpIndividual> = mutableListOf()
+
+    @PostConstruct
+    fun initialize() {
+        log.debug("Initializing {}", McpSampler::class.simpleName)
+
+        mcpClient = HttpMcpClient(config.bbTargetUrl)
+
+        actionCluster.clear()
+        toolActionCluster.clear()
+        resourceActionCluster.clear()
+
+        // Discover tools
+        val tools = mcpClient.listTools()
+        for (tool in tools) {
+            val inputGene = buildObjectGeneFromSchema("input", tool.inputSchema)
+            val action = McpToolCallAction(
+                toolName = tool.name,
+                inputSchema = inputGene,
+                description = tool.description
+            )
+            toolActionCluster[action.id] = action
+            actionCluster[action.id] = action
+        }
+
+        // Discover static resources
+        val resources = mcpClient.listResources()
+        for (resource in resources) {
+            val uri = StringGene("uri", resource.uri)
+            val action = McpResourceReadAction(uri = uri, isTemplate = false)
+            resourceActionCluster[action.id] = action
+            actionCluster[action.id] = action
+        }
+
+        // Discover resource templates
+        val templates = mcpClient.listResourceTemplates()
+        for (template in templates) {
+            val uri = StringGene("uri", template.uriTemplate)
+            val action = McpResourceReadAction(uri = uri, isTemplate = true)
+            // Use "template:" prefix to avoid collision with static resource keys
+            val key = "template:${template.uriTemplate}"
+            resourceActionCluster[key] = action
+            actionCluster[key] = action
+        }
+
+        customizeAdHocInitialIndividuals()
+
+        log.debug("Done initializing {} — {} tools, {} resources",
+            McpSampler::class.simpleName, toolActionCluster.size, resourceActionCluster.size)
+    }
+
+    // -------------------------------------------------------------------------
+    // Sampling
+    // -------------------------------------------------------------------------
+
+    override fun sampleAtRandom(): McpIndividual {
+        val allActions: List<McpAction> =
+            toolActionCluster.values.toList() + resourceActionCluster.values.toList()
+
+        if (allActions.isEmpty()) {
+            // Edge case: no capabilities discovered — return empty individual
+            val ind = McpIndividual(SampleType.RANDOM, mutableListOf())
+            ind.doGlobalInitialize(searchGlobalState)
+            return ind
+        }
+
+        val n = randomness.nextInt(1, getMaxTestSizeDuringSampler())
+        val groups: MutableList<ActionComponent> = (0 until n).map {
+            val action = randomness.choose(allActions).copy() as McpAction
+            action.doInitialize(randomness)
+            makeGroup(action)
+        }.toMutableList()
+
+        val ind = McpIndividual(SampleType.RANDOM, groups)
+        ind.doGlobalInitialize(searchGlobalState)
+        return ind
+    }
+
+    override fun smartSample(): McpIndividual {
+        if (adHocInitialIndividuals.isNotEmpty()) {
+            return adHocInitialIndividuals.removeAt(adHocInitialIndividuals.size - 1)
+        }
+        return sampleAtRandom()
+    }
+
+    override fun hasSpecialInitForSmartSampler(): Boolean = adHocInitialIndividuals.isNotEmpty()
+
+    override fun initSeededTests(infoDto: SutInfoDto?) {
+        // Not supported in Phase 3
+    }
+
+    // -------------------------------------------------------------------------
+    // AdHoc individuals — one per discovered capability
+    // -------------------------------------------------------------------------
+
+    private fun customizeAdHocInitialIndividuals() {
+        adHocInitialIndividuals.clear()
+
+        for ((_, action) in toolActionCluster) {
+            val copy = action.copy() as McpAction
+            copy.doInitialize(randomness)
+            val ind = McpIndividual(SampleType.RANDOM, mutableListOf(makeGroup(copy)))
+            ind.doGlobalInitialize(searchGlobalState)
+            adHocInitialIndividuals.add(ind)
+        }
+
+        for ((_, action) in resourceActionCluster) {
+            val copy = action.copy() as McpAction
+            copy.doInitialize(randomness)
+            val ind = McpIndividual(SampleType.RANDOM, mutableListOf(makeGroup(copy)))
+            ind.doGlobalInitialize(searchGlobalState)
+            adHocInitialIndividuals.add(ind)
+        }
+    }
+
+    /**
+     * Wrap a single [McpAction] in an [EnterpriseActionGroup].
+     * Uses the single-action convenience constructor.
+     */
+    private fun makeGroup(action: McpAction): EnterpriseActionGroup<McpAction> {
+        return EnterpriseActionGroup(action)
+    }
+
+    // -------------------------------------------------------------------------
+    // Gene building from JSON Schema
+    // -------------------------------------------------------------------------
+
+    /**
+     * Recursively build a [Gene] from a JSON Schema node.
+     *
+     * Supported types: string, integer, number, boolean, object, array.
+     * Unknown or missing types fall back to [StringGene].
+     */
+    internal fun buildGeneFromSchema(name: String, schema: Map<String, Any?>): Gene {
+        val type = schema["type"] as? String
+
+        return when (type) {
+            "string" -> StringGene(name)
+            "integer", "number" -> IntegerGene(name)
+            "boolean" -> BooleanGene(name)
+            "object" -> buildObjectGeneFromSchema(name, schema)
+            "array" -> ArrayGene(name, StringGene("element"))
+            else -> StringGene(name) // fallback for unknown/null types
+        }
+    }
+
+    /**
+     * Build an [ObjectGene] from a JSON Schema map.
+     * If the schema has no "properties" key, returns an empty [ObjectGene].
+     */
+    @Suppress("UNCHECKED_CAST")
+    internal fun buildObjectGeneFromSchema(name: String, schema: Map<String, Any?>): ObjectGene {
+        val properties = schema["properties"] as? Map<String, Any?> ?: emptyMap()
+        val fields = properties.entries.map { (propName, propSchema) ->
+            val propSchemaMap = propSchema as? Map<String, Any?> ?: emptyMap()
+            buildGeneFromSchema(propName, propSchemaMap)
+        }
+        return ObjectGene(name, fields)
+    }
+
+    // -------------------------------------------------------------------------
+    // Expose client for fitness function
+    // -------------------------------------------------------------------------
+
+    fun getMcpClient(): HttpMcpClient = mcpClient
+}

--- a/core/src/test/kotlin/org/evomaster/core/problem/mcp/McpActionTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/problem/mcp/McpActionTest.kt
@@ -1,0 +1,56 @@
+package org.evomaster.core.problem.mcp
+
+import org.evomaster.core.search.gene.ObjectGene
+import org.evomaster.core.search.gene.string.StringGene
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class McpActionTest {
+
+    @Test
+    fun `McpToolCallAction getName returns tool colon toolName`() {
+        val inputGene = ObjectGene("input", emptyList())
+        val action = McpToolCallAction("myTool", inputGene)
+        assertEquals("tool:myTool", action.getName())
+    }
+
+    @Test
+    fun `McpResourceReadAction getName starts with resource colon`() {
+        val uriGene = StringGene("uri", "http://example.com/resource")
+        val action = McpResourceReadAction(uriGene)
+        assertTrue(action.getName().startsWith("resource:"))
+    }
+
+    @Test
+    fun `seeTopGenes on McpToolCallAction returns the ObjectGene`() {
+        val inputGene = ObjectGene("input", emptyList())
+        val action = McpToolCallAction("myTool", inputGene)
+        val topGenes = action.seeTopGenes()
+        assertEquals(1, topGenes.size)
+        assertSame(inputGene, topGenes[0])
+    }
+
+    @Test
+    fun `copy on McpToolCallAction produces structurally equal but independent copy`() {
+        val inputGene = ObjectGene("input", emptyList())
+        val action = McpToolCallAction("myTool", inputGene, "a tool description")
+        val copy = action.copy() as McpToolCallAction
+
+        assertEquals(action.toolName, copy.toolName)
+        assertEquals(action.description, copy.description)
+        assertEquals(action.getName(), copy.getName())
+        // Must be independent: different gene instances
+        assertNotSame(action.inputSchema, copy.inputSchema)
+    }
+
+    @Test
+    fun `copy on McpResourceReadAction produces structurally equal but independent copy`() {
+        val uriGene = StringGene("uri", "file:///data/res")
+        val action = McpResourceReadAction(uriGene, isTemplate = true)
+        val copy = action.copy() as McpResourceReadAction
+
+        assertEquals(action.isTemplate, copy.isTemplate)
+        assertNotSame(action.uri, copy.uri)
+        assertEquals(action.uri.value, copy.uri.value)
+    }
+}

--- a/core/src/test/kotlin/org/evomaster/core/problem/mcp/McpIndividualTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/problem/mcp/McpIndividualTest.kt
@@ -1,0 +1,78 @@
+package org.evomaster.core.problem.mcp
+
+import org.evomaster.core.problem.enterprise.EnterpriseActionGroup
+import org.evomaster.core.problem.enterprise.SampleType
+import org.evomaster.core.search.GroupsOfChildren
+import org.evomaster.core.search.action.ActionComponent
+import org.evomaster.core.search.gene.ObjectGene
+import org.evomaster.core.search.gene.string.StringGene
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class McpIndividualTest {
+
+    private fun buildIndividual(vararg actions: McpAction): McpIndividual {
+        val wrappedActions: MutableList<EnterpriseActionGroup<McpAction>> =
+            actions.map { EnterpriseActionGroup(it) }.toMutableList()
+        @Suppress("UNCHECKED_CAST")
+        return McpIndividual(
+            sampleType = SampleType.RANDOM,
+            allActions = wrappedActions as MutableList<out ActionComponent>
+        )
+    }
+
+    @Test
+    fun `seeMainExecutableActions returns all actions`() {
+        val toolAction = McpToolCallAction("myTool", ObjectGene("input", emptyList()))
+        val resourceAction = McpResourceReadAction(StringGene("uri", "file:///data"))
+
+        val individual = buildIndividual(toolAction, resourceAction)
+
+        val mainActions = individual.seeMainExecutableActions()
+        assertEquals(2, mainActions.size)
+    }
+
+    @Test
+    fun `copyContent returns equal-sized independent copy`() {
+        val toolAction = McpToolCallAction("myTool", ObjectGene("input", emptyList()))
+        val resourceAction = McpResourceReadAction(StringGene("uri", "file:///data"))
+
+        val individual = buildIndividual(toolAction, resourceAction)
+        val copy = individual.copy() as McpIndividual
+
+        assertEquals(
+            individual.seeMainExecutableActions().size,
+            copy.seeMainExecutableActions().size
+        )
+        // Must be independent: different action instances
+        assertNotSame(
+            individual.seeMainExecutableActions()[0],
+            copy.seeMainExecutableActions()[0]
+        )
+    }
+
+    @Test
+    fun `addMcpAction increases action count`() {
+        val toolAction = McpToolCallAction("myTool", ObjectGene("input", emptyList()))
+        val individual = buildIndividual(toolAction)
+
+        assertEquals(1, individual.seeMainExecutableActions().size)
+
+        val newAction = McpToolCallAction("anotherTool", ObjectGene("input2", emptyList()))
+        individual.addMcpAction(action = newAction)
+
+        assertEquals(2, individual.seeMainExecutableActions().size)
+    }
+
+    @Test
+    fun `group size is tracked correctly`() {
+        val toolAction = McpToolCallAction("myTool", ObjectGene("input", emptyList()))
+        val resourceAction = McpResourceReadAction(StringGene("uri", "file:///data"))
+
+        val individual = buildIndividual(toolAction, resourceAction)
+
+        assertEquals(2, individual.groupsView()!!.sizeOfGroup(GroupsOfChildren.MAIN))
+        assertEquals(0, individual.groupsView()!!.sizeOfGroup(GroupsOfChildren.INITIALIZATION_SQL))
+        assertEquals(0, individual.groupsView()!!.sizeOfGroup(GroupsOfChildren.INITIALIZATION_MONGO))
+    }
+}

--- a/core/src/test/kotlin/org/evomaster/core/problem/mcp/client/HttpMcpClientTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/problem/mcp/client/HttpMcpClientTest.kt
@@ -1,0 +1,183 @@
+package org.evomaster.core.problem.mcp.client
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class HttpMcpClientTest {
+
+    private lateinit var wm: WireMockServer
+    private lateinit var client: HttpMcpClient
+
+    @BeforeEach
+    fun setUp() {
+        wm = WireMockServer(WireMockConfiguration().dynamicPort())
+        wm.start()
+        client = HttpMcpClient("http://localhost:${wm.port()}/mcp")
+    }
+
+    @AfterEach
+    fun tearDown() {
+        wm.stop()
+    }
+
+    private fun stubPost(responseBody: String) {
+        wm.stubFor(
+            WireMock.post(urlEqualTo("/mcp"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(responseBody)
+                )
+        )
+    }
+
+    @Test
+    fun `listTools parses tool definitions correctly`() {
+        stubPost(
+            """{"jsonrpc":"2.0","result":{"tools":[{"name":"foo","description":"bar","inputSchema":{}}]},"id":1}"""
+        )
+
+        val tools = client.listTools()
+
+        assertEquals(1, tools.size)
+        assertEquals("foo", tools[0].name)
+        assertEquals("bar", tools[0].description)
+    }
+
+    @Test
+    fun `listTools handles pagination with nextCursor`() {
+        // First page
+        wm.stubFor(
+            WireMock.post(urlEqualTo("/mcp"))
+                .inScenario("pagination")
+                .whenScenarioStateIs(com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED)
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(
+                            """{"jsonrpc":"2.0","result":{"tools":[{"name":"tool1","description":"","inputSchema":{}}],"nextCursor":"page2"},"id":1}"""
+                        )
+                )
+                .willSetStateTo("page2")
+        )
+        // Second page
+        wm.stubFor(
+            WireMock.post(urlEqualTo("/mcp"))
+                .inScenario("pagination")
+                .whenScenarioStateIs("page2")
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(
+                            """{"jsonrpc":"2.0","result":{"tools":[{"name":"tool2","description":"","inputSchema":{}}]},"id":2}"""
+                        )
+                )
+        )
+
+        val tools = client.listTools()
+
+        assertEquals(2, tools.size)
+        assertEquals("tool1", tools[0].name)
+        assertEquals("tool2", tools[1].name)
+    }
+
+    @Test
+    fun `callTool with isError false returns success result`() {
+        stubPost(
+            """{"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"hello"}],"isError":false},"id":1}"""
+        )
+
+        val result = client.callTool("foo", mapOf("arg" to "value"))
+
+        assertFalse(result.isError)
+        assertEquals(1, result.content.size)
+        assertEquals("text", result.content[0].type)
+        assertEquals("hello", result.content[0].text)
+    }
+
+    @Test
+    fun `callTool with isError true returns error result`() {
+        stubPost(
+            """{"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"error message"}],"isError":true},"id":1}"""
+        )
+
+        val result = client.callTool("foo", emptyMap())
+
+        assertTrue(result.isError)
+        assertEquals(1, result.content.size)
+        assertEquals("error message", result.content[0].text)
+    }
+
+    @Test
+    fun `callTool with missing result returns isError true`() {
+        stubPost(
+            """{"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found"},"id":1}"""
+        )
+
+        val result = client.callTool("nonexistent", emptyMap())
+
+        assertTrue(result.isError)
+        assertTrue(result.content.isEmpty())
+    }
+
+    @Test
+    fun `readResource parses content correctly`() {
+        stubPost(
+            """{"jsonrpc":"2.0","result":{"contents":[{"type":"text","text":"resource content","uri":"file:///data/res"}]},"id":1}"""
+        )
+
+        val result = client.readResource("file:///data/res")
+
+        assertEquals(1, result.contents.size)
+        assertEquals("text", result.contents[0].type)
+        assertEquals("resource content", result.contents[0].text)
+        assertEquals("file:///data/res", result.contents[0].uri)
+    }
+
+    @Test
+    fun `readResource with missing result returns empty contents`() {
+        stubPost(
+            """{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params"},"id":1}"""
+        )
+
+        val result = client.readResource("unknown://uri")
+
+        assertTrue(result.contents.isEmpty())
+    }
+
+    @Test
+    fun `listResources parses resource definitions correctly`() {
+        stubPost(
+            """{"jsonrpc":"2.0","result":{"resources":[{"uri":"file:///data","name":"data","description":"A data resource","mimeType":"application/json"}]},"id":1}"""
+        )
+
+        val resources = client.listResources()
+
+        assertEquals(1, resources.size)
+        assertEquals("file:///data", resources[0].uri)
+        assertEquals("data", resources[0].name)
+        assertEquals("application/json", resources[0].mimeType)
+    }
+
+    @Test
+    fun `listResourceTemplates parses templates correctly`() {
+        stubPost(
+            """{"jsonrpc":"2.0","result":{"resourceTemplates":[{"uriTemplate":"file:///{path}","name":"fileTemplate","description":"A file template"}]},"id":1}"""
+        )
+
+        val templates = client.listResourceTemplates()
+
+        assertEquals(1, templates.size)
+        assertEquals("file:///{path}", templates[0].uriTemplate)
+        assertEquals("fileTemplate", templates[0].name)
+    }
+}


### PR DESCRIPTION
Introduces a new problem domain for blackbox testing of MCP (Model Context Protocol) servers, following the same architecture as the existing GraphQL and RPC problem domains.

New components under core/src/main/kotlin/.../problem/mcp/:
- McpAction (abstract base), McpToolCallAction (tools/call), McpResourceReadAction (resources/read), McpInputParam, McpUriParam
- McpIndividual: chromosome wrapping sequences of MCP actions
- McpCallResult: per-action execution record storing isError flag
- client/McpClient (interface), client/HttpMcpClient (JSON-RPC 2.0 over HTTP with pagination), client/McpDTOs
- service/McpSampler: @PostConstruct discovery via tools/list, resources/list, resources/templates/list; gene tree building from JSON Schema; random and smart (ad-hoc) sampling
- service/McpFitness (abstract base), service/McpBlackBoxFitness: per-action scoring using isError flag and successful reads as signals
- service/McpBlackBoxModule: Guice bindings mirroring GraphQLBlackBoxModule

Unit tests cover action construction, individual copy/mutation, and HttpMcpClient JSON-RPC parsing via WireMock stubs.