### PR TITLE
fix(oom-rc3): skip re-encoding in initializeIfNeeded when modelKeys a…

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/problem/rest/classifier/probabilistic/AbstractProbabilistic400EndpointModel.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/rest/classifier/probabilistic/AbstractProbabilistic400EndpointModel.kt
@@ -82,6 +82,12 @@ abstract class AbstractProbabilistic400EndpointModel(
             return
         }
 
+        if (modelKeys != null && dimension != null) {
+            require(warmup > 0) { "Warmup must be positive" }
+            initialized = true
+            return
+        }
+
         val encoder = InputEncoderUtilWrapper(input, encoderType = encoderType)
         val allParamsPathsAndEncodedValues = encoder.getAllParamsPathsAndEncodedValues()
 


### PR DESCRIPTION
…lready set