### PR TITLE
http oracle - invalid allow

### DIFF
--- a/core-tests/e2e-tests/spring/spring-rest-openapi-v3/src/main/kotlin/com/foo/rest/examples/spring/openapi/v3/httporacle/invalidallow/base/HttpInvalidAllowApplication.kt
+++ b/core-tests/e2e-tests/spring/spring-rest-openapi-v3/src/main/kotlin/com/foo/rest/examples/spring/openapi/v3/httporacle/invalidallow/base/HttpInvalidAllowApplication.kt
@@ -1,0 +1,73 @@
+package com.foo.rest.examples.spring.openapi.v3.httporacle.invalidallow.base
+
+import io.swagger.v3.oas.annotations.Hidden
+import org.springframework.boot.SpringApplication
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+
+@SpringBootApplication(exclude = [SecurityAutoConfiguration::class])
+@RequestMapping(path = ["/api"])
+@RestController
+open class HttpInvalidAllowApplication {
+
+    companion object {
+        @JvmStatic
+        fun main(args: Array<String>) {
+            SpringApplication.run(HttpInvalidAllowApplication::class.java, *args)
+        }
+
+        private val products = mutableMapOf<Int, String>()
+        private val orders = mutableMapOf<Int, String>()
+
+        fun reset() {
+            products.clear()
+            orders.clear()
+        }
+    }
+
+    // Faulty resource: DELETE is mapped but hidden from the schema,
+    // so OPTIONS Allow lists a verb (DELETE) not documented in OpenAPI.
+
+    @GetMapping(path = ["/products/{id}"])
+    open fun getProduct(@PathVariable("id") id: Int): ResponseEntity<String> {
+        val value = products[id] ?: return ResponseEntity.status(404).build()
+        return ResponseEntity.status(200).body(value)
+    }
+
+    @PutMapping(path = ["/products/{id}"])
+    open fun putProduct(@PathVariable("id") id: Int): ResponseEntity<Any> {
+        val isNew = !products.containsKey(id)
+        products[id] = "$id"
+        return ResponseEntity.status(if (isNew) 201 else 200).build()
+    }
+
+    @Hidden
+    @DeleteMapping(path = ["/products/{id}"])
+    open fun deleteProduct(@PathVariable("id") id: Int): ResponseEntity<Any> {
+        products.remove(id)
+        return ResponseEntity.status(204).build()
+    }
+
+    // Clean resource: Allow matches the schema (ignoring HEAD/OPTIONS).
+
+    @GetMapping(path = ["/orders/{id}"])
+    open fun getOrder(@PathVariable("id") id: Int): ResponseEntity<String> {
+        val value = orders[id] ?: return ResponseEntity.status(404).build()
+        return ResponseEntity.status(200).body(value)
+    }
+
+    @PutMapping(path = ["/orders/{id}"])
+    open fun putOrder(@PathVariable("id") id: Int): ResponseEntity<Any> {
+        val isNew = !orders.containsKey(id)
+        orders[id] = "$id"
+        return ResponseEntity.status(if (isNew) 201 else 200).build()
+    }
+}

--- a/core-tests/e2e-tests/spring/spring-rest-openapi-v3/src/main/kotlin/com/foo/rest/examples/spring/openapi/v3/httporacle/invalidallow/missing/HttpMissingAllowApplication.kt
+++ b/core-tests/e2e-tests/spring/spring-rest-openapi-v3/src/main/kotlin/com/foo/rest/examples/spring/openapi/v3/httporacle/invalidallow/missing/HttpMissingAllowApplication.kt
@@ -1,11 +1,9 @@
-package com.foo.rest.examples.spring.openapi.v3.httporacle.invalidallow.base
+package com.foo.rest.examples.spring.openapi.v3.httporacle.invalidallow.missing
 
-import io.swagger.v3.oas.annotations.Hidden
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
@@ -16,12 +14,12 @@ import org.springframework.web.bind.annotation.RestController
 @SpringBootApplication(exclude = [SecurityAutoConfiguration::class])
 @RequestMapping(path = ["/api"])
 @RestController
-open class HttpInvalidAllowApplication {
+open class HttpMissingAllowApplication {
 
     companion object {
         @JvmStatic
         fun main(args: Array<String>) {
-            SpringApplication.run(HttpInvalidAllowApplication::class.java, *args)
+            SpringApplication.run(HttpMissingAllowApplication::class.java, *args)
         }
 
         private val products = mutableMapOf<Int, String>()
@@ -33,8 +31,8 @@ open class HttpInvalidAllowApplication {
         }
     }
 
-    // Faulty resource: DELETE is mapped but hidden from the schema,
-    // so OPTIONS Allow lists a verb (DELETE) not documented in OpenAPI.
+    // Faulty resource: the manual schema declares DELETE, but no DELETE handler is mapped,
+    // so OPTIONS Allow omits a verb (DELETE) that is documented in OpenAPI.
 
     @GetMapping(path = ["/products/{id}"])
     open fun getProduct(@PathVariable("id") id: Int): ResponseEntity<String> {
@@ -49,14 +47,8 @@ open class HttpInvalidAllowApplication {
         return ResponseEntity.status(if (isNew) 201 else 200).build()
     }
 
-    @Hidden
-    @DeleteMapping(path = ["/products/{id}"])
-    open fun deleteProduct(@PathVariable("id") id: Int): ResponseEntity<Any> {
-        products.remove(id)
-        return ResponseEntity.status(204).build()
-    }
-
     // Clean resource: Allow matches the schema (ignoring HEAD/OPTIONS).
+
     @GetMapping(path = ["/orders/{id}"])
     open fun getOrder(@PathVariable("id") id: Int): ResponseEntity<String> {
         val value = orders[id] ?: return ResponseEntity.status(404).build()

--- a/core-tests/e2e-tests/spring/spring-rest-openapi-v3/src/main/resources/static/openapi-missingallow.yml
+++ b/core-tests/e2e-tests/spring/spring-rest-openapi-v3/src/main/resources/static/openapi-missingallow.yml
@@ -1,0 +1,73 @@
+openapi: 3.0.0
+info:
+  title: Missing Allow API
+  version: 1.0.0
+paths:
+  # Faulty resource: declares DELETE, but the server has no DELETE handler,
+  # so OPTIONS Allow omits a declared verb.
+  /api/products/{id}:
+    get:
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: Found
+        "404":
+          description: Not found
+    put:
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: Updated
+        "201":
+          description: Created
+    delete:
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "204":
+          description: Deleted
+  # Clean resource: declared verbs match the served ones.
+  /api/orders/{id}:
+    get:
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: Found
+        "404":
+          description: Not found
+    put:
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: Updated
+        "201":
+          description: Created

--- a/core-tests/e2e-tests/spring/spring-rest-openapi-v3/src/test/kotlin/com/foo/rest/examples/spring/openapi/v3/httporacle/invalidallow/HttpInvalidAllowController.kt
+++ b/core-tests/e2e-tests/spring/spring-rest-openapi-v3/src/test/kotlin/com/foo/rest/examples/spring/openapi/v3/httporacle/invalidallow/HttpInvalidAllowController.kt
@@ -1,0 +1,12 @@
+package com.foo.rest.examples.spring.openapi.v3.httporacle.invalidallow
+
+import com.foo.rest.examples.spring.openapi.v3.SpringController
+import com.foo.rest.examples.spring.openapi.v3.httporacle.invalidallow.base.HttpInvalidAllowApplication
+
+
+class HttpInvalidAllowController : SpringController(HttpInvalidAllowApplication::class.java) {
+
+    override fun resetStateOfSUT() {
+        HttpInvalidAllowApplication.reset()
+    }
+}

--- a/core-tests/e2e-tests/spring/spring-rest-openapi-v3/src/test/kotlin/com/foo/rest/examples/spring/openapi/v3/httporacle/invalidallow/missing/HttpMissingAllowController.kt
+++ b/core-tests/e2e-tests/spring/spring-rest-openapi-v3/src/test/kotlin/com/foo/rest/examples/spring/openapi/v3/httporacle/invalidallow/missing/HttpMissingAllowController.kt
@@ -1,0 +1,20 @@
+package com.foo.rest.examples.spring.openapi.v3.httporacle.invalidallow.missing
+
+import com.foo.rest.examples.spring.openapi.v3.SpringController
+import org.evomaster.client.java.controller.problem.ProblemInfo
+import org.evomaster.client.java.controller.problem.RestProblem
+
+
+class HttpMissingAllowController : SpringController(HttpMissingAllowApplication::class.java) {
+
+    override fun resetStateOfSUT() {
+        HttpMissingAllowApplication.reset()
+    }
+
+    override fun getProblemInfo(): ProblemInfo {
+        return RestProblem(
+            "http://localhost:$sutPort/openapi-missingallow.yml",
+            null
+        )
+    }
+}

--- a/core-tests/e2e-tests/spring/spring-rest-openapi-v3/src/test/kotlin/org/evomaster/e2etests/spring/openapi/v3/httporacle/invalidallow/HttpInvalidAllowEMTest.kt
+++ b/core-tests/e2e-tests/spring/spring-rest-openapi-v3/src/test/kotlin/org/evomaster/e2etests/spring/openapi/v3/httporacle/invalidallow/HttpInvalidAllowEMTest.kt
@@ -1,0 +1,51 @@
+package org.evomaster.e2etests.spring.openapi.v3.httporacle.invalidallow
+
+import com.foo.rest.examples.spring.openapi.v3.httporacle.invalidallow.HttpInvalidAllowController
+import org.evomaster.core.problem.enterprise.DetectedFaultUtils
+import org.evomaster.core.problem.enterprise.ExperimentalFaultCategory
+import org.evomaster.e2etests.spring.openapi.v3.SpringTestBase
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+
+class HttpInvalidAllowEMTest : SpringTestBase() {
+
+    companion object {
+        @BeforeAll
+        @JvmStatic
+        fun init() {
+            initClass(HttpInvalidAllowController())
+        }
+    }
+
+
+    @Test
+    fun testRunEM() {
+
+        runTestHandlingFlakyAndCompilation(
+                "HttpInvalidAllowEM",
+                20
+        ) { args: MutableList<String> ->
+
+            setOption(args, "security", "false")
+            setOption(args, "schemaOracles", "false")
+            setOption(args, "httpOracles", "true")
+            setOption(args, "useExperimentalOracles", "true")
+
+            val solution = initAndRun(args)
+
+            assertTrue(solution.individuals.size >= 1)
+
+            val faults = DetectedFaultUtils.getDetectedFaultCategories(solution)
+            assertTrue({ ExperimentalFaultCategory.HTTP_INVALID_ALLOW in faults })
+
+            val allowFaults = DetectedFaultUtils.getDetectedFaults(solution)
+                .filter { it.category == ExperimentalFaultCategory.HTTP_INVALID_ALLOW }
+
+            // fault on the path with the hidden DELETE verb
+            assertTrue(allowFaults.any { it.operationId.contains("/api/products/") })
+            // no false positive on the clean path
+            assertTrue(allowFaults.none { it.operationId.contains("/api/orders/") })
+        }
+    }
+}

--- a/core-tests/e2e-tests/spring/spring-rest-openapi-v3/src/test/kotlin/org/evomaster/e2etests/spring/openapi/v3/httporacle/invalidallow/missing/HttpMissingAllowEMTest.kt
+++ b/core-tests/e2e-tests/spring/spring-rest-openapi-v3/src/test/kotlin/org/evomaster/e2etests/spring/openapi/v3/httporacle/invalidallow/missing/HttpMissingAllowEMTest.kt
@@ -1,6 +1,6 @@
-package org.evomaster.e2etests.spring.openapi.v3.httporacle.invalidallow
+package org.evomaster.e2etests.spring.openapi.v3.httporacle.invalidallow.missing
 
-import com.foo.rest.examples.spring.openapi.v3.httporacle.invalidallow.HttpInvalidAllowController
+import com.foo.rest.examples.spring.openapi.v3.httporacle.invalidallow.missing.HttpMissingAllowController
 import org.evomaster.core.problem.enterprise.DetectedFaultUtils
 import org.evomaster.core.problem.enterprise.ExperimentalFaultCategory
 import org.evomaster.e2etests.spring.openapi.v3.SpringTestBase
@@ -8,13 +8,13 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 
-class HttpInvalidAllowEMTest : SpringTestBase() {
+class HttpMissingAllowEMTest : SpringTestBase() {
 
     companion object {
         @BeforeAll
         @JvmStatic
         fun init() {
-            initClass(HttpInvalidAllowController())
+            initClass(HttpMissingAllowController())
         }
     }
 
@@ -23,7 +23,7 @@ class HttpInvalidAllowEMTest : SpringTestBase() {
     fun testRunEM() {
 
         runTestHandlingFlakyAndCompilation(
-                "HttpInvalidAllowEM",
+                "HttpMissingAllowEM",
                 20
         ) { args: MutableList<String> ->
 
@@ -37,7 +37,7 @@ class HttpInvalidAllowEMTest : SpringTestBase() {
             assertTrue(solution.individuals.size >= 1)
 
             val faults = DetectedFaultUtils.getDetectedFaultCategories(solution)
-            assertTrue({ ExperimentalFaultCategory.HTTP_INVALID_ALLOW in faults })
+            assertTrue(ExperimentalFaultCategory.HTTP_INVALID_ALLOW in faults)
 
             val allowFaults = DetectedFaultUtils.getDetectedFaults(solution)
                 .filter { it.category == ExperimentalFaultCategory.HTTP_INVALID_ALLOW }

--- a/core/src/main/kotlin/org/evomaster/core/problem/enterprise/ExperimentalFaultCategory.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/enterprise/ExperimentalFaultCategory.kt
@@ -37,6 +37,8 @@ enum class ExperimentalFaultCategory(
 
     HTTP_NON_IDEMPOTENT_PUT(918, "PUT is idempotent", "nonIdempotentPut",
         "TODO"),
+    HTTP_INVALID_ALLOW(919, "Invalid allow", "invalidAllow",
+        "TODO"),
 
     HTTP_STATUS_NO_NON_STANDARD_CODES(950, "no-non-standard-codes", "invalidStatusCode", "TODO"),
     HTTP_STATUS_NO_201_IF_DELETE(951, "no-201-if-delete", "201OnDelete",  "TODO"),

--- a/core/src/main/kotlin/org/evomaster/core/problem/rest/service/HttpSemanticsService.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/rest/service/HttpSemanticsService.kt
@@ -12,6 +12,7 @@ import org.evomaster.core.problem.rest.data.RestCallAction
 import org.evomaster.core.problem.rest.data.RestCallResult
 import org.evomaster.core.problem.rest.data.RestIndividual
 import org.evomaster.core.problem.rest.data.RestPath
+import org.evomaster.core.problem.rest.param.PathParam
 import org.evomaster.core.problem.rest.service.fitness.RestFitness
 import org.evomaster.core.problem.rest.service.sampler.AbstractRestSampler
 import org.evomaster.core.search.EvaluatedIndividual
@@ -127,6 +128,40 @@ class HttpSemanticsService : TimeBoxedPhase{
         if(hasPhaseTimedOut()) return
         // – invalid location, leading to a 404 when doing a follow up GET
         invalidLocation()
+
+        if(hasPhaseTimedOut()) return
+        invalidAllow()
+    }
+
+    /**
+     * For each path, make a single OPTIONS call. The Allow header must not list
+     * verbs that are not declared in the schema (ignoring OPTIONS and HEAD).
+     */
+    private fun invalidAllow() {
+
+        // OPTIONS has no schema template, so the resource sampler cannot build such an
+        // individual. We build it directly, reusing the shared search global state.
+        val globalState = individualsInSolution.firstOrNull()?.individual?.searchGlobalState ?: return
+
+        val actions = actionDefinitions.distinctBy { it.path }
+
+        for (a in actions) {
+
+            if (hasPhaseTimedOut()) return
+
+            val pathVariables = a.parameters
+                .filterIsInstance<PathParam>()
+                .map { it.copy() }
+                .toMutableList()
+
+            val path = a.path.copy()
+            val options = RestCallAction("${HttpVerb.OPTIONS}:$path", HttpVerb.OPTIONS, path, pathVariables, a.auth)
+            options.doInitialize(randomness)
+
+            val ind = RestIndividual(mutableListOf(options), SampleType.HTTP_SEMANTICS)
+            ind.doGlobalInitialize(globalState)
+            prepareEvaluateAndSave(ind)
+        }
     }
 
     /**

--- a/core/src/main/kotlin/org/evomaster/core/problem/rest/service/fitness/AbstractRestFitness.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/rest/service/fitness/AbstractRestFitness.kt
@@ -1352,6 +1352,40 @@ abstract class AbstractRestFitness : HttpWsFitness<RestIndividual>() {
         if(config.isEnabledFaultCategory(ExperimentalFaultCategory.HTTP_INVALID_LOCATION)) {
             handleInvalidLocation(individual, actionResults, fv)
         }
+
+        if(config.isEnabledFaultCategory(ExperimentalFaultCategory.HTTP_INVALID_ALLOW)) {
+            handleInvalidAllow(individual, actionResults, fv)
+        }
+    }
+
+    /**
+     * Check any OPTIONS call, regardless of its position. The Allow header must not list
+     * verbs that are not declared in the schema (ignoring OPTIONS and HEAD).
+     */
+    private fun handleInvalidAllow(
+        individual: RestIndividual,
+        actionResults: List<ActionResult>,
+        fv: FitnessValue
+    ) {
+        val actions = individual.seeMainExecutableActions()
+
+        for (index in actions.indices) {
+            val a = actions[index]
+            if (a.verb != HttpVerb.OPTIONS) continue
+
+            val r = actionResults.find { it.sourceLocalId == a.getLocalId() } as RestCallResult? ?: continue
+            val allowed = r.getAllowedVerbs() ?: continue
+
+            val extra = allowed.any {
+                it != HttpVerb.OPTIONS && it != HttpVerb.HEAD && !callGraphService.isDeclared(it, a.path)
+            }
+            if (!extra) continue
+
+            val category = ExperimentalFaultCategory.HTTP_INVALID_ALLOW
+            val scenarioId = idMapper.handleLocalTarget(idMapper.getFaultDescriptiveId(category, a.getName()))
+            fv.updateTarget(scenarioId, 1.0, index)
+            r.addFault(DetectedFault(category, a.getName(), null))
+        }
     }
 
     private fun handleFailedModification(

--- a/core/src/main/kotlin/org/evomaster/core/problem/rest/service/fitness/AbstractRestFitness.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/rest/service/fitness/AbstractRestFitness.kt
@@ -1379,11 +1379,13 @@ abstract class AbstractRestFitness : HttpWsFitness<RestIndividual>() {
             val r = actionResults.find { it.sourceLocalId == a.getLocalId() } as RestCallResult? ?: continue
             val allowed = r.getAllowedVerbs() ?: continue
 
+            // listed in Allow but not declared in the schema
             val extra = allowed.any {
                 it != HttpVerb.OPTIONS && it != HttpVerb.HEAD && !callGraphService.isDeclared(it, a.path)
             }
-            val missing = callGraphService.endpointsForPath(a.path).any {
-                it.verb != HttpVerb.OPTIONS && it.verb != HttpVerb.HEAD && !allowed.contains(it.verb)
+            // declared in the schema but not listed in Allow
+            val missing = HttpVerb.values().any {
+                it != HttpVerb.OPTIONS && it != HttpVerb.HEAD && callGraphService.isDeclared(it, a.path) && it !in allowed
             }
             if (!extra && !missing) continue
 

--- a/core/src/main/kotlin/org/evomaster/core/problem/rest/service/fitness/AbstractRestFitness.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/rest/service/fitness/AbstractRestFitness.kt
@@ -1359,8 +1359,11 @@ abstract class AbstractRestFitness : HttpWsFitness<RestIndividual>() {
     }
 
     /**
-     * Check any OPTIONS call, regardless of its position. The Allow header must not list
-     * verbs that are not declared in the schema (ignoring OPTIONS and HEAD).
+     * Check any OPTIONS call, regardless of its position. The Allow header must match
+     * the verbs declared in the schema (ignoring OPTIONS and HEAD). Two faults, both
+     * reported under HTTP_INVALID_ALLOW:
+     * - extra: a verb is allowed but not declared in the schema
+     * - missing: a verb is declared in the schema but absent from the Allow header
      */
     private fun handleInvalidAllow(
         individual: RestIndividual,
@@ -1379,7 +1382,10 @@ abstract class AbstractRestFitness : HttpWsFitness<RestIndividual>() {
             val extra = allowed.any {
                 it != HttpVerb.OPTIONS && it != HttpVerb.HEAD && !callGraphService.isDeclared(it, a.path)
             }
-            if (!extra) continue
+            val missing = callGraphService.endpointsForPath(a.path).any {
+                it.verb != HttpVerb.OPTIONS && it.verb != HttpVerb.HEAD && !allowed.contains(it.verb)
+            }
+            if (!extra && !missing) continue
 
             val category = ExperimentalFaultCategory.HTTP_INVALID_ALLOW
             val scenarioId = idMapper.handleLocalTarget(idMapper.getFaultDescriptiveId(category, a.getName()))

--- a/core/src/main/kotlin/org/evomaster/core/problem/rest/service/fitness/AbstractRestFitness.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/rest/service/fitness/AbstractRestFitness.kt
@@ -1377,22 +1377,29 @@ abstract class AbstractRestFitness : HttpWsFitness<RestIndividual>() {
             if (a.verb != HttpVerb.OPTIONS) continue
 
             val r = actionResults.find { it.sourceLocalId == a.getLocalId() } as RestCallResult? ?: continue
+            // The Allow header is not mandatory in an OPTIONS response
+            // (see https://httpwg.org/specs/rfc9110.html#OPTIONS), so if it is
+            // missing we cannot conclude anything, ie it is not a fault.
             val allowed = r.getAllowedVerbs() ?: continue
 
             // listed in Allow but not declared in the schema
-            val extra = allowed.any {
+            val extra = allowed.filter {
                 it != HttpVerb.OPTIONS && it != HttpVerb.HEAD && !callGraphService.isDeclared(it, a.path)
-            }
+            }.sorted()
             // declared in the schema but not listed in Allow
-            val missing = HttpVerb.values().any {
+            val missing = HttpVerb.values().filter {
                 it != HttpVerb.OPTIONS && it != HttpVerb.HEAD && callGraphService.isDeclared(it, a.path) && it !in allowed
             }
-            if (!extra && !missing) continue
+            if (extra.isEmpty() && missing.isEmpty()) continue
 
             val category = ExperimentalFaultCategory.HTTP_INVALID_ALLOW
             val scenarioId = idMapper.handleLocalTarget(idMapper.getFaultDescriptiveId(category, a.getName()))
             fv.updateTarget(scenarioId, 1.0, index)
-            r.addFault(DetectedFault(category, a.getName(), null))
+            val localMessage = listOfNotNull(
+                extra.takeIf { it.isNotEmpty() }?.let { "extra verbs: $it" },
+                missing.takeIf { it.isNotEmpty() }?.let { "missing verbs: $it" }
+            ).joinToString("; ")
+            r.addFault(DetectedFault(category, a.getName(), null, localMessage))
         }
     }
 


### PR DESCRIPTION
Example test:

    /**
    * Calls:
    * (200) OPTIONS:/api/products/{id}
    * Found 1 potential fault of type-code 919
    */
    @Test @Timeout(60)
    fun test_5_optionsOnProductInvalidAllow()  {
        
        // Fault919. Invalid allow.
        given().accept("*/*")
                .options("${baseUrlOfSut}/api/products/771")
                .then()
                .statusCode(200)
                .assertThat()
                // .header("Allow", "HEAD,DELETE,GET,OPTIONS,PUT")
                .body(isEmptyOrNullString())
    }
    