### PR TITLE
Kotlin test writer dollar sign escape bug

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/output/SqlWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/SqlWriter.kt
@@ -110,6 +110,14 @@ object SqlWriter {
                 //TODO already escaped???
                 return x.replace("\"","\\\"")
             }
+            if (format.isKotlin()) {
+                // Applying escapeJava on top would corrupt Kotlin escapes, e.g. \$ -> \\$
+                // so remove the kotlin specific escapes ($), apply the java escapes and then reapply the kotlin escapes
+                val unescapedKotlin = x.replace("\\\$", "$")
+                val escapedJava = StringEscapeUtils.escapeJava(unescapedKotlin)
+                val escapedKotlin = escapedJava.replace("$", "\\\$")
+                return escapedKotlin
+            }
             return StringEscapeUtils.escapeJava(x)
             //TODO this is an atypical treatment of escapes. Should we run all escapes through the same procedure?
             // or is this special enough to be justified?

--- a/core/src/main/kotlin/org/evomaster/core/output/SqlWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/SqlWriter.kt
@@ -110,14 +110,6 @@ object SqlWriter {
                 //TODO already escaped???
                 return x.replace("\"","\\\"")
             }
-            if (format.isKotlin()) {
-                // Applying escapeJava on top would corrupt Kotlin escapes, e.g. \$ -> \\$
-                // so remove the kotlin specific escapes ($), apply the java escapes and then reapply the kotlin escapes
-                val unescapedKotlin = x.replace("\\\$", "$")
-                val escapedJava = StringEscapeUtils.escapeJava(unescapedKotlin)
-                val escapedKotlin = escapedJava.replace("$", "\\\$")
-                return escapedKotlin
-            }
             return StringEscapeUtils.escapeJava(x)
             //TODO this is an atypical treatment of escapes. Should we run all escapes through the same procedure?
             // or is this special enough to be justified?

--- a/core/src/main/kotlin/org/evomaster/core/output/SqlWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/SqlWriter.kt
@@ -110,13 +110,21 @@ object SqlWriter {
                 //TODO already escaped???
                 return x.replace("\"","\\\"")
             }
-            return StringEscapeUtils.escapeJava(x)
+            return when {
+                format.isJava() -> StringEscapeUtils.escapeJava(x)
+                format.isKotlin() -> escapeKotlin(x)
+                else -> throw IllegalStateException("Output format $format is not valid for SQL test case generation")
+            }
             //TODO this is an atypical treatment of escapes. Should we run all escapes through the same procedure?
             // or is this special enough to be justified?
             /*
                 FIXME: Yep, escaping in EM is currently a total mess... will need to be refactored/cleaned up
              */
         }
+    }
+
+    private fun escapeKotlin(value: String): String {
+        return StringEscapeUtils.escapeJava(value).replace("\\$", "\$")
     }
 
     private fun handleFK(format: OutputFormat, fkg: SqlForeignKeyGene, action: SqlAction, allActions: List<SqlAction>): String {

--- a/core/src/main/kotlin/org/evomaster/core/output/SqlWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/SqlWriter.kt
@@ -124,6 +124,12 @@ object SqlWriter {
     }
 
     private fun escapeKotlin(value: String): String {
+        /*
+         * Kotlin strings use `$` for interpolation. `getValueAsPrintableString` with kotlin format
+         * already escapes the dollar sign as `\$`. `escapeJava` would escape it again, producing
+         * `\\$` (a double-escaped `$`). We replace this with a single `\$` so the value
+         * is safe for Kotlin source generation.
+         */
         return StringEscapeUtils.escapeJava(value).replace("\\$", "\$")
     }
 

--- a/core/src/test/kotlin/org/evomaster/core/output/TestCaseWriterTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/output/TestCaseWriterTest.kt
@@ -1679,4 +1679,40 @@ public void test() throws Exception {
         assertFalse(lines.toString().contains(".body()"))
 
     }
+
+    @Test
+    fun testStringWithDollarKotlin() {
+        // A StringGene value containing '$' must be escaped as '\$' in generated Kotlin source. Currently,
+        // SqlWriter.getPrintableValue applies StringEscapeUtils.escapeJava() after GeneUtils.applyEscapes(),
+        // which doubles the backslash and leaves '$' bare, causing a Kotlin string template compile error.
+        val aColumn = Column("name", VARCHAR, 10, databaseType = DatabaseType.H2)
+        val aTable = Table("myTable", setOf(aColumn), HashSet<ForeignKey>())
+
+        val gene = StringGene("name", "v\$t")
+        val insertAction = SqlAction(aTable, setOf(aColumn), 0L, mutableListOf(gene))
+
+        val (_, baseUrlOfSut, ei) = buildEvaluatedIndividual(mutableListOf(insertAction))
+
+        val format = OutputFormat.KOTLIN_JUNIT_5
+        val writer = RestTestCaseWriter(getConfig(format), PartialOracles())
+        val lines = writer.convertToCompilableTestCode(TestCase(test = ei, name = "test"), baseUrlOfSut)
+
+        val expectedLines = Lines(format).apply {
+            add("@Test")
+            add("fun test()  {")
+            indent()
+            add("val insertions = sql().insertInto(\"myTable\", 0L)")
+            indent()
+            indent()
+            add(".d(\"name\", \"\\\"v\\\$t\\\"\")")
+            deindent()
+            add(".dtos()")
+            deindent()
+            add("val insertionsresult = controller.execInsertionsIntoDatabase(insertions)")
+            deindent()
+            add("}")
+        }
+
+        assertEquals(expectedLines.toString(), lines.toString())
+    }
 }


### PR DESCRIPTION
Kotlin requires `$` symbols to be escaped when writing strings. Bug fix for double escape of dollar sign symbols, as `SqlWriter` escaped the already escaped dollar signs, resulting in bare dollar signs appearing on generated Kotlin code (causing compilation errors).