### PR TITLE
Regex java external flags

### DIFF
--- a/client-java/instrumentation-shared/src/main/java/org/evomaster/client/java/instrumentation/shared/StringSpecializationInfo.java
+++ b/client-java/instrumentation-shared/src/main/java/org/evomaster/client/java/instrumentation/shared/StringSpecializationInfo.java
@@ -53,6 +53,10 @@ public class StringSpecializationInfo implements Serializable {
         return type;
     }
 
+    /**
+     * Getter for regex flags bitmask, only meaningful when stringSpecialization is regex type. Defaults to 0 (no flags)
+     * @return Integer bitmask for the regex flags associated to the string.
+     */
     public int getRegexFlags() { return regexFlags; }
 
     @Override

--- a/client-java/instrumentation-shared/src/main/java/org/evomaster/client/java/instrumentation/shared/StringSpecializationInfo.java
+++ b/client-java/instrumentation-shared/src/main/java/org/evomaster/client/java/instrumentation/shared/StringSpecializationInfo.java
@@ -16,17 +16,29 @@ public class StringSpecializationInfo implements Serializable {
 
     private final TaintType type;
 
+    /**
+     * External regex flags bitmask, as accepted by java.util.regex.Pattern.compile(String, int).
+     * Only meaningful when stringSpecialization is a regex type.
+     * Defaults to 0 (no external flags).
+     */
+    private final int regexFlags;
+
     public StringSpecializationInfo(StringSpecialization stringSpecialization, String value) {
         this(stringSpecialization, value, TaintType.FULL_MATCH);
     }
 
     public StringSpecializationInfo(StringSpecialization stringSpecialization, String value, TaintType taintType) {
+        this(stringSpecialization, value, taintType, 0);
+    }
+
+    public StringSpecializationInfo(StringSpecialization stringSpecialization, String value, TaintType taintType, int regexFlags) {
         this.stringSpecialization = Objects.requireNonNull(stringSpecialization);
         this.value = value;
         if(taintType == null || taintType == TaintType.NONE){
             throw new IllegalArgumentException("Invalid type: "+taintType);
         }
         this.type = taintType;
+        this.regexFlags = regexFlags;
     }
 
     public StringSpecialization getStringSpecialization() {
@@ -41,6 +53,8 @@ public class StringSpecializationInfo implements Serializable {
         return type;
     }
 
+    public int getRegexFlags() { return regexFlags; }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -48,11 +62,12 @@ public class StringSpecializationInfo implements Serializable {
         StringSpecializationInfo that = (StringSpecializationInfo) o;
         return stringSpecialization == that.stringSpecialization &&
                 Objects.equals(value, that.value) &&
-                type == that.type;
+                type == that.type &&
+                regexFlags == that.regexFlags;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(stringSpecialization, value, type);
+        return Objects.hash(stringSpecialization, value, type, regexFlags);
     }
 }

--- a/client-java/instrumentation-shared/src/main/java/org/evomaster/client/java/instrumentation/shared/StringSpecializationInfo.java
+++ b/client-java/instrumentation-shared/src/main/java/org/evomaster/client/java/instrumentation/shared/StringSpecializationInfo.java
@@ -21,7 +21,7 @@ public class StringSpecializationInfo implements Serializable {
      * Only meaningful when stringSpecialization is a regex type.
      * Defaults to 0 (no external flags).
      */
-    private final int regexFlags;
+    private final int externalRegexFlagsBitmask;
 
     public StringSpecializationInfo(StringSpecialization stringSpecialization, String value) {
         this(stringSpecialization, value, TaintType.FULL_MATCH);
@@ -31,14 +31,14 @@ public class StringSpecializationInfo implements Serializable {
         this(stringSpecialization, value, taintType, 0);
     }
 
-    public StringSpecializationInfo(StringSpecialization stringSpecialization, String value, TaintType taintType, int regexFlags) {
+    public StringSpecializationInfo(StringSpecialization stringSpecialization, String value, TaintType taintType, int externalRegexFlagsBitmask) {
         this.stringSpecialization = Objects.requireNonNull(stringSpecialization);
         this.value = value;
         if(taintType == null || taintType == TaintType.NONE){
             throw new IllegalArgumentException("Invalid type: "+taintType);
         }
         this.type = taintType;
-        this.regexFlags = regexFlags;
+        this.externalRegexFlagsBitmask = externalRegexFlagsBitmask;
     }
 
     public StringSpecialization getStringSpecialization() {
@@ -57,7 +57,7 @@ public class StringSpecializationInfo implements Serializable {
      * Getter for regex flags bitmask, only meaningful when stringSpecialization is regex type. Defaults to 0 (no flags)
      * @return Integer bitmask for the regex flags associated to the string.
      */
-    public int getRegexFlags() { return regexFlags; }
+    public int getExternalRegexFlagsBitmask() { return externalRegexFlagsBitmask; }
 
     @Override
     public boolean equals(Object o) {
@@ -67,11 +67,11 @@ public class StringSpecializationInfo implements Serializable {
         return stringSpecialization == that.stringSpecialization &&
                 Objects.equals(value, that.value) &&
                 type == that.type &&
-                regexFlags == that.regexFlags;
+                externalRegexFlagsBitmask == that.externalRegexFlagsBitmask;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(stringSpecialization, value, type, regexFlags);
+        return Objects.hash(stringSpecialization, value, type, externalRegexFlagsBitmask);
     }
 }

--- a/client-java/instrumentation/src/main/java/org/evomaster/client/java/instrumentation/coverage/methodreplacement/PatternMatchingHelper.java
+++ b/client-java/instrumentation/src/main/java/org/evomaster/client/java/instrumentation/coverage/methodreplacement/PatternMatchingHelper.java
@@ -5,6 +5,7 @@ import org.evomaster.client.java.distance.heuristics.Truthness;
 import org.evomaster.client.java.instrumentation.shared.ReplacementType;
 import org.evomaster.client.java.instrumentation.shared.StringSpecialization;
 import org.evomaster.client.java.instrumentation.shared.StringSpecializationInfo;
+import org.evomaster.client.java.instrumentation.shared.TaintType;
 import org.evomaster.client.java.instrumentation.staticstate.ExecutionTracer;
 
 import java.util.Objects;
@@ -31,7 +32,7 @@ public class PatternMatchingHelper {
 
         if (ExecutionTracer.isTaintInput(input)) {
             ExecutionTracer.addStringSpecialization(input,
-                    new StringSpecializationInfo(StringSpecialization.REGEX_WHOLE, regex));
+                    new StringSpecializationInfo(StringSpecialization.REGEX_WHOLE, regex, TaintType.FULL_MATCH, flags));
         }
 
         Pattern p = Pattern.compile(regex, flags);

--- a/client-java/instrumentation/src/main/java/org/evomaster/client/java/instrumentation/coverage/methodreplacement/PatternMatchingHelper.java
+++ b/client-java/instrumentation/src/main/java/org/evomaster/client/java/instrumentation/coverage/methodreplacement/PatternMatchingHelper.java
@@ -26,16 +26,16 @@ public class PatternMatchingHelper {
         /**
          * Invocation to Pattern.matches() is free of side-effects.
          */
-    public static boolean matches(String regex, int flags, String input, String idTemplate) {
+    public static boolean matches(String regex, int externalRegexFlagsBitmask, String input, String idTemplate) {
         Objects.requireNonNull(regex);
         Objects.requireNonNull(input);
 
         if (ExecutionTracer.isTaintInput(input)) {
             ExecutionTracer.addStringSpecialization(input,
-                    new StringSpecializationInfo(StringSpecialization.REGEX_WHOLE, regex, TaintType.FULL_MATCH, flags));
+                    new StringSpecializationInfo(StringSpecialization.REGEX_WHOLE, regex, TaintType.FULL_MATCH, externalRegexFlagsBitmask));
         }
 
-        Pattern p = Pattern.compile(regex, flags);
+        Pattern p = Pattern.compile(regex, externalRegexFlagsBitmask);
         Matcher m = p.matcher(input);
         boolean matches = m.matches();
 

--- a/client-java/instrumentation/src/main/java/org/evomaster/client/java/instrumentation/coverage/methodreplacement/classes/MatcherClassReplacement.java
+++ b/client-java/instrumentation/src/main/java/org/evomaster/client/java/instrumentation/coverage/methodreplacement/classes/MatcherClassReplacement.java
@@ -48,9 +48,9 @@ public class MatcherClassReplacement implements MethodReplacementClass {
 
         String text = getText(caller);
         String pattern = caller.pattern().toString();
-        int flags = caller.pattern().flags();
+        int regexFlags = caller.pattern().flags();
 
-        boolean patternMatchesResult = PatternMatchingHelper.matches(pattern, flags, text, idTemplate);
+        boolean patternMatchesResult = PatternMatchingHelper.matches(pattern, regexFlags, text, idTemplate);
 
         TaintType taintType = ExecutionTracer.getTaintType(text);
 
@@ -60,7 +60,7 @@ public class MatcherClassReplacement implements MethodReplacementClass {
              */
             String regex = caller.pattern().toString();
             ExecutionTracer.addStringSpecialization(text,
-                    new StringSpecializationInfo(StringSpecialization.REGEX_WHOLE, regex, taintType, flags));
+                    new StringSpecializationInfo(StringSpecialization.REGEX_WHOLE, regex, taintType, regexFlags));
         }
         boolean matcherMatchesResults = caller.matches();
         assert (patternMatchesResult == matcherMatchesResults);
@@ -73,7 +73,7 @@ public class MatcherClassReplacement implements MethodReplacementClass {
 
         String input = getText(caller);
         String regex = caller.pattern().toString();
-        int flags = caller.pattern().flags();
+        int regexFlags = caller.pattern().flags();
         int end;
         try {
             end = caller.end();
@@ -106,7 +106,7 @@ public class MatcherClassReplacement implements MethodReplacementClass {
         TaintType taintType = ExecutionTracer.getTaintType(substring);
         if (taintType.isTainted()) {
             ExecutionTracer.addStringSpecialization(substring,
-                    new StringSpecializationInfo(StringSpecialization.REGEX_PARTIAL, regex, taintType, flags));
+                    new StringSpecializationInfo(StringSpecialization.REGEX_PARTIAL, regex, taintType, regexFlags));
         }
 
         String anyPositionRegexMatch = RegexSharedUtils.handlePartialMatch(regex);

--- a/client-java/instrumentation/src/main/java/org/evomaster/client/java/instrumentation/coverage/methodreplacement/classes/MatcherClassReplacement.java
+++ b/client-java/instrumentation/src/main/java/org/evomaster/client/java/instrumentation/coverage/methodreplacement/classes/MatcherClassReplacement.java
@@ -48,9 +48,9 @@ public class MatcherClassReplacement implements MethodReplacementClass {
 
         String text = getText(caller);
         String pattern = caller.pattern().toString();
-        int regexFlags = caller.pattern().flags();
+        int externalRegexFlagsBitmask = caller.pattern().flags();
 
-        boolean patternMatchesResult = PatternMatchingHelper.matches(pattern, regexFlags, text, idTemplate);
+        boolean patternMatchesResult = PatternMatchingHelper.matches(pattern, externalRegexFlagsBitmask, text, idTemplate);
 
         TaintType taintType = ExecutionTracer.getTaintType(text);
 
@@ -60,7 +60,7 @@ public class MatcherClassReplacement implements MethodReplacementClass {
              */
             String regex = caller.pattern().toString();
             ExecutionTracer.addStringSpecialization(text,
-                    new StringSpecializationInfo(StringSpecialization.REGEX_WHOLE, regex, taintType, regexFlags));
+                    new StringSpecializationInfo(StringSpecialization.REGEX_WHOLE, regex, taintType, externalRegexFlagsBitmask));
         }
         boolean matcherMatchesResults = caller.matches();
         assert (patternMatchesResult == matcherMatchesResults);
@@ -73,7 +73,7 @@ public class MatcherClassReplacement implements MethodReplacementClass {
 
         String input = getText(caller);
         String regex = caller.pattern().toString();
-        int regexFlags = caller.pattern().flags();
+        int externalRegexFlagsBitmask = caller.pattern().flags();
         int end;
         try {
             end = caller.end();
@@ -106,7 +106,7 @@ public class MatcherClassReplacement implements MethodReplacementClass {
         TaintType taintType = ExecutionTracer.getTaintType(substring);
         if (taintType.isTainted()) {
             ExecutionTracer.addStringSpecialization(substring,
-                    new StringSpecializationInfo(StringSpecialization.REGEX_PARTIAL, regex, taintType, regexFlags));
+                    new StringSpecializationInfo(StringSpecialization.REGEX_PARTIAL, regex, taintType, externalRegexFlagsBitmask));
         }
 
         String anyPositionRegexMatch = RegexSharedUtils.handlePartialMatch(regex);

--- a/client-java/instrumentation/src/main/java/org/evomaster/client/java/instrumentation/coverage/methodreplacement/classes/MatcherClassReplacement.java
+++ b/client-java/instrumentation/src/main/java/org/evomaster/client/java/instrumentation/coverage/methodreplacement/classes/MatcherClassReplacement.java
@@ -60,7 +60,7 @@ public class MatcherClassReplacement implements MethodReplacementClass {
              */
             String regex = caller.pattern().toString();
             ExecutionTracer.addStringSpecialization(text,
-                    new StringSpecializationInfo(StringSpecialization.REGEX_WHOLE, regex, taintType));
+                    new StringSpecializationInfo(StringSpecialization.REGEX_WHOLE, regex, taintType, flags));
         }
         boolean matcherMatchesResults = caller.matches();
         assert (patternMatchesResult == matcherMatchesResults);
@@ -73,6 +73,7 @@ public class MatcherClassReplacement implements MethodReplacementClass {
 
         String input = getText(caller);
         String regex = caller.pattern().toString();
+        int flags = caller.pattern().flags();
         int end;
         try {
             end = caller.end();
@@ -105,7 +106,7 @@ public class MatcherClassReplacement implements MethodReplacementClass {
         TaintType taintType = ExecutionTracer.getTaintType(substring);
         if (taintType.isTainted()) {
             ExecutionTracer.addStringSpecialization(substring,
-                    new StringSpecializationInfo(StringSpecialization.REGEX_PARTIAL, regex, taintType));
+                    new StringSpecializationInfo(StringSpecialization.REGEX_PARTIAL, regex, taintType, flags));
         }
 
         String anyPositionRegexMatch = RegexSharedUtils.handlePartialMatch(regex);

--- a/core/src/main/kotlin/org/evomaster/core/parser/GeneRegexJavaVisitor.kt
+++ b/core/src/main/kotlin/org/evomaster/core/parser/GeneRegexJavaVisitor.kt
@@ -11,7 +11,7 @@ private const val EOF_TOKEN = "<EOF>"
 /**
  * Created by arcuri82 on 11-Sep-19.
  */
-class GeneRegexJavaVisitor : RegexJavaBaseVisitor<VisitResult>(){
+class GeneRegexJavaVisitor(externalFlags: RegexFlags = RegexFlags()) : RegexJavaBaseVisitor<VisitResult>(){
 
     private val hexEscapePrefixes = setOf('x', 'u')
 
@@ -52,8 +52,9 @@ class GeneRegexJavaVisitor : RegexJavaBaseVisitor<VisitResult>(){
     /**
      * Tracks the flags active in the current lexical scope.
      * Updated when entering a flag group, restored on exit.
+     * Initialized from [externalFlags].
      */
-    private var currentFlags = RegexFlags()
+    private var currentFlags = externalFlags
 
     /**
      * Parses a FLAG_GROUP_OPEN or FLAG_SCOPE_OPEN token text like "(?i:", "(?iu:", "(?-i:", "(?i-u:", "(?iu)", etc.

--- a/core/src/main/kotlin/org/evomaster/core/parser/GeneRegexJavaVisitor.kt
+++ b/core/src/main/kotlin/org/evomaster/core/parser/GeneRegexJavaVisitor.kt
@@ -11,7 +11,7 @@ private const val EOF_TOKEN = "<EOF>"
 /**
  * Created by arcuri82 on 11-Sep-19.
  */
-class GeneRegexJavaVisitor(externalFlags: RegexFlags = RegexFlags()) : RegexJavaBaseVisitor<VisitResult>(){
+class GeneRegexJavaVisitor(externalRegexFlags: RegexFlags = RegexFlags()) : RegexJavaBaseVisitor<VisitResult>(){
 
     private val hexEscapePrefixes = setOf('x', 'u')
 
@@ -52,9 +52,9 @@ class GeneRegexJavaVisitor(externalFlags: RegexFlags = RegexFlags()) : RegexJava
     /**
      * Tracks the flags active in the current lexical scope.
      * Updated when entering a flag group, restored on exit.
-     * Initialized from [externalFlags].
+     * Initialized from [externalRegexFlags].
      */
-    private var currentFlags = externalFlags
+    private var currentFlags = externalRegexFlags
 
     /**
      * Parses a FLAG_GROUP_OPEN or FLAG_SCOPE_OPEN token text like "(?i:", "(?iu:", "(?-i:", "(?i-u:", "(?iu)", etc.

--- a/core/src/main/kotlin/org/evomaster/core/parser/RegexHandler.kt
+++ b/core/src/main/kotlin/org/evomaster/core/parser/RegexHandler.kt
@@ -4,7 +4,7 @@ import org.antlr.v4.runtime.*
 import org.antlr.v4.runtime.misc.ParseCancellationException
 import org.evomaster.core.search.gene.regex.RegexGene
 import org.evomaster.core.utils.RegexFlags
-import org.evomaster.core.utils.RegexWithFlags
+import org.evomaster.core.utils.RegexWithExternalFlags
 
 
 /**
@@ -21,14 +21,14 @@ object RegexHandler {
         WARNING mutable static state, but those are just caches.
         Key -> regex
      */
-    private val cacheJVM : MutableMap<RegexWithFlags, RegexGene> = mutableMapOf()
+    private val cacheJVM : MutableMap<RegexWithExternalFlags, RegexGene> = mutableMapOf()
     private val cacheEcma262 : MutableMap<String, RegexGene> = mutableMapOf()
     private val cachePostgresLike : MutableMap<String, RegexGene> = mutableMapOf()
     private val cachePostgresSimilarTo : MutableMap<String, RegexGene> = mutableMapOf()
 
-    fun createGeneForJVM(regex: String, flags: RegexFlags = RegexFlags()) : RegexGene {
+    fun createGeneForJVM(regex: String, externalRegexFlags: RegexFlags = RegexFlags()) : RegexGene {
 
-        val key = RegexWithFlags(regex, flags)
+        val key = RegexWithExternalFlags(regex, externalRegexFlags)
         if(cacheJVM.contains(key)){
             return cacheJVM[key]!!.copy() as RegexGene
         }
@@ -41,7 +41,7 @@ object RegexHandler {
 
         val pattern = parser.pattern()
 
-        val res = GeneRegexJavaVisitor(flags).visit(pattern)
+        val res = GeneRegexJavaVisitor(externalRegexFlags).visit(pattern)
 
         val gene= res.genes.first() as RegexGene
         cacheJVM[key] = gene.copy() as RegexGene

--- a/core/src/main/kotlin/org/evomaster/core/parser/RegexHandler.kt
+++ b/core/src/main/kotlin/org/evomaster/core/parser/RegexHandler.kt
@@ -4,6 +4,7 @@ import org.antlr.v4.runtime.*
 import org.antlr.v4.runtime.misc.ParseCancellationException
 import org.evomaster.core.search.gene.regex.RegexGene
 import org.evomaster.core.utils.RegexFlags
+import org.evomaster.core.utils.RegexWithFlags
 
 
 /**
@@ -20,14 +21,14 @@ object RegexHandler {
         WARNING mutable static state, but those are just caches.
         Key -> regex
      */
-    private val cacheJVM : MutableMap<Pair<String, RegexFlags>, RegexGene> = mutableMapOf()
+    private val cacheJVM : MutableMap<RegexWithFlags, RegexGene> = mutableMapOf()
     private val cacheEcma262 : MutableMap<String, RegexGene> = mutableMapOf()
     private val cachePostgresLike : MutableMap<String, RegexGene> = mutableMapOf()
     private val cachePostgresSimilarTo : MutableMap<String, RegexGene> = mutableMapOf()
 
     fun createGeneForJVM(regex: String, flags: RegexFlags = RegexFlags()) : RegexGene {
 
-        val key = Pair(regex, flags)
+        val key = RegexWithFlags(regex, flags)
         if(cacheJVM.contains(key)){
             return cacheJVM[key]!!.copy() as RegexGene
         }

--- a/core/src/main/kotlin/org/evomaster/core/parser/RegexHandler.kt
+++ b/core/src/main/kotlin/org/evomaster/core/parser/RegexHandler.kt
@@ -3,6 +3,7 @@ package org.evomaster.core.parser
 import org.antlr.v4.runtime.*
 import org.antlr.v4.runtime.misc.ParseCancellationException
 import org.evomaster.core.search.gene.regex.RegexGene
+import org.evomaster.core.utils.RegexFlags
 
 
 /**
@@ -19,15 +20,16 @@ object RegexHandler {
         WARNING mutable static state, but those are just caches.
         Key -> regex
      */
-    private val cacheJVM : MutableMap<String, RegexGene> = mutableMapOf()
+    private val cacheJVM : MutableMap<Pair<String, RegexFlags>, RegexGene> = mutableMapOf()
     private val cacheEcma262 : MutableMap<String, RegexGene> = mutableMapOf()
     private val cachePostgresLike : MutableMap<String, RegexGene> = mutableMapOf()
     private val cachePostgresSimilarTo : MutableMap<String, RegexGene> = mutableMapOf()
 
-    fun createGeneForJVM(regex: String) : RegexGene {
+    fun createGeneForJVM(regex: String, flags: RegexFlags = RegexFlags()) : RegexGene {
 
-        if(cacheJVM.contains(regex)){
-            return cacheJVM[regex]!!.copy() as RegexGene
+        val key = Pair(regex, flags)
+        if(cacheJVM.contains(key)){
+            return cacheJVM[key]!!.copy() as RegexGene
         }
 
         val stream = CharStreams.fromString(regex)
@@ -38,10 +40,10 @@ object RegexHandler {
 
         val pattern = parser.pattern()
 
-        val res = GeneRegexJavaVisitor().visit(pattern)
+        val res = GeneRegexJavaVisitor(flags).visit(pattern)
 
         val gene= res.genes.first() as RegexGene
-        cacheJVM[regex] = gene.copy() as RegexGene
+        cacheJVM[key] = gene.copy() as RegexGene
         return gene
     }
 

--- a/core/src/main/kotlin/org/evomaster/core/search/gene/string/StringGene.kt
+++ b/core/src/main/kotlin/org/evomaster/core/search/gene/string/StringGene.kt
@@ -36,6 +36,7 @@ import org.evomaster.core.search.service.Randomness
 import org.evomaster.core.search.service.mutator.MutationWeightControl
 import org.evomaster.core.search.service.mutator.genemutation.AdditionalGeneMutationInfo
 import org.evomaster.core.search.service.mutator.genemutation.SubsetGeneMutationSelectionStrategy
+import org.evomaster.core.utils.RegexFlags
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.lang.IllegalStateException
@@ -811,16 +812,17 @@ class StringGene(
                     .filter{RegexUtils.isMeaningfulRegex(it.value)}
                     .filter{RegexUtils.isNotUselessRegex(it.value) }
                     .map {
-                        if(it.stringSpecialization == StringSpecialization.REGEX_WHOLE) {
+                        val regex = if(it.stringSpecialization == StringSpecialization.REGEX_WHOLE) {
                             RegexSharedUtils.forceFullMatch(it.value)
                         } else {
                             RegexSharedUtils.handlePartialMatch(it.value)
                         }
+                        Pair(regex, RegexFlags.fromJavaFlags(it.regexFlags))
                     }
                     //.joinToString("|")
-                    .forEach {regex ->
+                    .forEach {(regex, flags) ->
                       try {
-                              toAddGenes.add(RegexHandler.createGeneForJVM(regex))
+                              toAddGenes.add(RegexHandler.createGeneForJVM(regex, flags))
                               log.trace("Regex, added specification for: {}", regex)
                           } catch (e: Exception) {
                               LoggingUtil.uniqueWarn(log, "Failed to handle regex: $regex")

--- a/core/src/main/kotlin/org/evomaster/core/search/gene/string/StringGene.kt
+++ b/core/src/main/kotlin/org/evomaster/core/search/gene/string/StringGene.kt
@@ -36,7 +36,7 @@ import org.evomaster.core.search.service.Randomness
 import org.evomaster.core.search.service.mutator.MutationWeightControl
 import org.evomaster.core.search.service.mutator.genemutation.AdditionalGeneMutationInfo
 import org.evomaster.core.search.service.mutator.genemutation.SubsetGeneMutationSelectionStrategy
-import org.evomaster.core.utils.RegexFlags
+import org.evomaster.core.utils.RegexWithFlags
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.lang.IllegalStateException
@@ -817,7 +817,7 @@ class StringGene(
                         } else {
                             RegexSharedUtils.handlePartialMatch(it.value)
                         }
-                        Pair(regex, RegexFlags.fromJavaFlags(it.regexFlags))
+                        RegexWithFlags(regex, it.regexFlags)
                     }
                     //.joinToString("|")
                     .forEach {(regex, flags) ->

--- a/core/src/main/kotlin/org/evomaster/core/search/gene/string/StringGene.kt
+++ b/core/src/main/kotlin/org/evomaster/core/search/gene/string/StringGene.kt
@@ -817,7 +817,7 @@ class StringGene(
                         } else {
                             RegexSharedUtils.handlePartialMatch(it.value)
                         }
-                        RegexWithFlags(regex, it.regexFlags)
+                        RegexWithFlags(regex, it.externalRegexFlagsBitmask)
                     }
                     //.joinToString("|")
                     .forEach {(regex, flags) ->

--- a/core/src/main/kotlin/org/evomaster/core/search/gene/string/StringGene.kt
+++ b/core/src/main/kotlin/org/evomaster/core/search/gene/string/StringGene.kt
@@ -36,7 +36,7 @@ import org.evomaster.core.search.service.Randomness
 import org.evomaster.core.search.service.mutator.MutationWeightControl
 import org.evomaster.core.search.service.mutator.genemutation.AdditionalGeneMutationInfo
 import org.evomaster.core.search.service.mutator.genemutation.SubsetGeneMutationSelectionStrategy
-import org.evomaster.core.utils.RegexWithFlags
+import org.evomaster.core.utils.RegexWithExternalFlags
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.lang.IllegalStateException
@@ -817,12 +817,12 @@ class StringGene(
                         } else {
                             RegexSharedUtils.handlePartialMatch(it.value)
                         }
-                        RegexWithFlags(regex, it.externalRegexFlagsBitmask)
+                        RegexWithExternalFlags(regex, it.externalRegexFlagsBitmask)
                     }
                     //.joinToString("|")
-                    .forEach {(regex, flags) ->
+                    .forEach {(regex, externalFlags) ->
                       try {
-                              toAddGenes.add(RegexHandler.createGeneForJVM(regex, flags))
+                              toAddGenes.add(RegexHandler.createGeneForJVM(regex, externalFlags))
                               log.trace("Regex, added specification for: {}", regex)
                           } catch (e: Exception) {
                               LoggingUtil.uniqueWarn(log, "Failed to handle regex: $regex")

--- a/core/src/main/kotlin/org/evomaster/core/utils/RegexFlags.kt
+++ b/core/src/main/kotlin/org/evomaster/core/utils/RegexFlags.kt
@@ -66,14 +66,14 @@ data class RegexFlags(
          * [java.util.regex.Pattern.compile] to be preserved and applied when building
          * the gene tree, mirroring the behaviour of the Java regex engine.
          */
-        fun fromJavaFlags(flags: Int): RegexFlags = RegexFlags(
-            caseInsensitive       = flags and Pattern.CASE_INSENSITIVE != 0,
-            unicodeCase           = flags and Pattern.UNICODE_CASE != 0,
-            dotAll                = flags and Pattern.DOTALL != 0,
-            multiline             = flags and Pattern.MULTILINE != 0,
-            unixLines             = flags and Pattern.UNIX_LINES != 0,
-            unicodeCharacterClass = flags and Pattern.UNICODE_CHARACTER_CLASS != 0,
-            comments              = flags and Pattern.COMMENTS != 0
+        fun fromExternalJavaRegexFlagBitmask(externalRegexFlagsBitmask: Int): RegexFlags = RegexFlags(
+            caseInsensitive       = externalRegexFlagsBitmask and Pattern.CASE_INSENSITIVE != 0,
+            unicodeCase           = externalRegexFlagsBitmask and Pattern.UNICODE_CASE != 0,
+            dotAll                = externalRegexFlagsBitmask and Pattern.DOTALL != 0,
+            multiline             = externalRegexFlagsBitmask and Pattern.MULTILINE != 0,
+            unixLines             = externalRegexFlagsBitmask and Pattern.UNIX_LINES != 0,
+            unicodeCharacterClass = externalRegexFlagsBitmask and Pattern.UNICODE_CHARACTER_CLASS != 0,
+            comments              = externalRegexFlagsBitmask and Pattern.COMMENTS != 0
         )
     }
 

--- a/core/src/main/kotlin/org/evomaster/core/utils/RegexFlags.kt
+++ b/core/src/main/kotlin/org/evomaster/core/utils/RegexFlags.kt
@@ -1,5 +1,7 @@
 package org.evomaster.core.utils
 
+import java.util.regex.Pattern
+
 /**
  * Represents a parsed flag expression like "(?iu-s:".
  * Encapsulates the flags being turned on and off, to be applied to an existing [RegexFlags] via [RegexFlags.merge].
@@ -57,6 +59,22 @@ data class RegexFlags(
                 comments              = 'x' in s,
             )
         }
+
+        /**
+         * Constructs a [RegexFlags] from a Java regex flags bitmask, as accepted by
+         * [java.util.regex.Pattern.compile]. This allows external flags passed to
+         * [java.util.regex.Pattern.compile] to be preserved and applied when building
+         * the gene tree, mirroring the behaviour of the Java regex engine.
+         */
+        fun fromJavaFlags(flags: Int): RegexFlags = RegexFlags(
+            caseInsensitive       = flags and Pattern.CASE_INSENSITIVE != 0,
+            unicodeCase           = flags and Pattern.UNICODE_CASE != 0,
+            dotAll                = flags and Pattern.DOTALL != 0,
+            multiline             = flags and Pattern.MULTILINE != 0,
+            unixLines             = flags and Pattern.UNIX_LINES != 0,
+            unicodeCharacterClass = flags and Pattern.UNICODE_CHARACTER_CLASS != 0,
+            comments              = flags and Pattern.COMMENTS != 0
+        )
     }
 
     /**

--- a/core/src/main/kotlin/org/evomaster/core/utils/RegexWithExternalFlags.kt
+++ b/core/src/main/kotlin/org/evomaster/core/utils/RegexWithExternalFlags.kt
@@ -1,0 +1,5 @@
+package org.evomaster.core.utils
+
+data class RegexWithExternalFlags(val regex: String, val externalRegexFlags: RegexFlags) {
+    constructor (regex: String, externalRegexFlagBitmask: Int) : this(regex, RegexFlags.fromExternalJavaRegexFlagBitmask(externalRegexFlagBitmask))
+}

--- a/core/src/main/kotlin/org/evomaster/core/utils/RegexWithFlags.kt
+++ b/core/src/main/kotlin/org/evomaster/core/utils/RegexWithFlags.kt
@@ -1,0 +1,5 @@
+package org.evomaster.core.utils
+
+data class RegexWithFlags(val regex: String, val regexFlags: RegexFlags) {
+    constructor (regex: String, regexFlagInt: Int) : this(regex, RegexFlags.fromJavaFlags(regexFlagInt))
+}

--- a/core/src/main/kotlin/org/evomaster/core/utils/RegexWithFlags.kt
+++ b/core/src/main/kotlin/org/evomaster/core/utils/RegexWithFlags.kt
@@ -1,5 +1,0 @@
-package org.evomaster.core.utils
-
-data class RegexWithFlags(val regex: String, val regexFlags: RegexFlags) {
-    constructor (regex: String, regexFlagInt: Int) : this(regex, RegexFlags.fromExternalJavaRegexFlagBitmask(regexFlagInt))
-}

--- a/core/src/main/kotlin/org/evomaster/core/utils/RegexWithFlags.kt
+++ b/core/src/main/kotlin/org/evomaster/core/utils/RegexWithFlags.kt
@@ -1,5 +1,5 @@
 package org.evomaster.core.utils
 
 data class RegexWithFlags(val regex: String, val regexFlags: RegexFlags) {
-    constructor (regex: String, regexFlagInt: Int) : this(regex, RegexFlags.fromJavaFlags(regexFlagInt))
+    constructor (regex: String, regexFlagInt: Int) : this(regex, RegexFlags.fromExternalJavaRegexFlagBitmask(regexFlagInt))
 }

--- a/core/src/test/kotlin/org/evomaster/core/parser/RegexHandlerTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/parser/RegexHandlerTest.kt
@@ -3,7 +3,6 @@ package org.evomaster.core.parser
 import org.antlr.v4.runtime.misc.ParseCancellationException
 import org.evomaster.client.java.instrumentation.heuristic.ValidatorHeuristics
 import org.evomaster.client.java.instrumentation.shared.RegexSharedUtils
-import org.evomaster.core.search.gene.regex.RegexGene
 import org.evomaster.core.search.service.AdaptiveParameterControl
 import org.evomaster.core.search.service.Randomness
 import org.evomaster.core.search.service.mutator.MutationWeightControl
@@ -11,7 +10,6 @@ import org.evomaster.core.utils.RegexFlags
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import java.util.regex.Pattern
 
 internal class RegexHandlerTest{
@@ -176,7 +174,7 @@ internal class RegexHandlerTest{
     fun testJVMExternalCaseInsensitiveFlagWithUnicodeCase() {
         // \u03A1 is greek capital Rho, \u03C1 is lowercase rho
         val regex = "\u03A1+"
-        val flags = RegexFlags.fromJavaFlags(Pattern.CASE_INSENSITIVE or Pattern.UNICODE_CASE)
+        val flags = RegexFlags.fromExternalJavaRegexFlagBitmask(Pattern.CASE_INSENSITIVE or Pattern.UNICODE_CASE)
         val gene = RegexHandler.createGeneForJVM(regex, flags)
         val pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE or Pattern.UNICODE_CASE)
         val rand = Randomness()
@@ -193,7 +191,7 @@ internal class RegexHandlerTest{
 
         val regex = "^abc$"
         val noFlags = RegexHandler.createGeneForJVM(regex)
-        val withCI = RegexHandler.createGeneForJVM(regex, RegexFlags.fromJavaFlags(Pattern.CASE_INSENSITIVE))
+        val withCI = RegexHandler.createGeneForJVM(regex, RegexFlags.fromExternalJavaRegexFlagBitmask(Pattern.CASE_INSENSITIVE))
 
         val rand = Randomness()
         val noFlagsSamples = (1..200).map {
@@ -214,7 +212,7 @@ internal class RegexHandlerTest{
     fun testJVMInlineFlagNotDoubledByExternalFlag() {
 
         val regex = "(?i:abc)"
-        val withExternalCI = RegexHandler.createGeneForJVM(regex, RegexFlags.fromJavaFlags(Pattern.CASE_INSENSITIVE))
+        val withExternalCI = RegexHandler.createGeneForJVM(regex, RegexFlags.fromExternalJavaRegexFlagBitmask(Pattern.CASE_INSENSITIVE))
         val pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE)
         val rand = Randomness()
 
@@ -229,7 +227,7 @@ internal class RegexHandlerTest{
     fun testJVMInlineCanDisableExternalFlag() {
 
         val regex = "^(?-i:abc)$"
-        val withExternalCI = RegexHandler.createGeneForJVM(regex, RegexFlags.fromJavaFlags(Pattern.CASE_INSENSITIVE))
+        val withExternalCI = RegexHandler.createGeneForJVM(regex, RegexFlags.fromExternalJavaRegexFlagBitmask(Pattern.CASE_INSENSITIVE))
         val rand = Randomness()
 
         repeat(200) {

--- a/core/src/test/kotlin/org/evomaster/core/parser/RegexHandlerTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/parser/RegexHandlerTest.kt
@@ -7,6 +7,7 @@ import org.evomaster.core.search.gene.regex.RegexGene
 import org.evomaster.core.search.service.AdaptiveParameterControl
 import org.evomaster.core.search.service.Randomness
 import org.evomaster.core.search.service.mutator.MutationWeightControl
+import org.evomaster.core.utils.RegexFlags
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
@@ -169,5 +170,72 @@ internal class RegexHandlerTest{
         assertThrows(ParseCancellationException::class.java) { RegexHandler.createGeneForEcma262("\\xR") }
         assertThrows(ParseCancellationException::class.java) { RegexHandler.createGeneForJVM("\\ugggg") }
         assertThrows(IllegalArgumentException::class.java) { RegexHandler.createGeneForJVM("[9-1]") }
+    }
+
+    @Test
+    fun testJVMExternalCaseInsensitiveFlagWithUnicodeCase() {
+        // \u03A1 is greek capital Rho, \u03C1 is lowercase rho
+        val regex = "\u03A1+"
+        val flags = RegexFlags.fromJavaFlags(Pattern.CASE_INSENSITIVE or Pattern.UNICODE_CASE)
+        val gene = RegexHandler.createGeneForJVM(regex, flags)
+        val pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE or Pattern.UNICODE_CASE)
+        val rand = Randomness()
+
+        repeat(200) {
+            gene.randomize(rand, false)
+            val value = gene.getValueAsRawString()
+            assertTrue(pattern.matcher(value).find())
+        }
+    }
+
+    @Test
+    fun testJVMCacheDistinguishesByExternalFlags() {
+
+        val regex = "^abc$"
+        val noFlags = RegexHandler.createGeneForJVM(regex)
+        val withCI = RegexHandler.createGeneForJVM(regex, RegexFlags.fromJavaFlags(Pattern.CASE_INSENSITIVE))
+
+        val rand = Randomness()
+        val noFlagsSamples = (1..200).map {
+            noFlags.randomize(rand, false)
+            noFlags.getValueAsRawString()
+        }.toSet()
+
+        val withCISamples = (1..200).map {
+            withCI.randomize(rand, false)
+            withCI.getValueAsRawString()
+        }.toSet()
+
+        assertTrue(noFlagsSamples.all { it == "abc" })
+        assertTrue(withCISamples.size > 1)
+    }
+
+    @Test
+    fun testJVMInlineFlagNotDoubledByExternalFlag() {
+
+        val regex = "(?i:abc)"
+        val withExternalCI = RegexHandler.createGeneForJVM(regex, RegexFlags.fromJavaFlags(Pattern.CASE_INSENSITIVE))
+        val pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE)
+        val rand = Randomness()
+
+        repeat(200) {
+            withExternalCI.randomize(rand, false)
+            val value = withExternalCI.getValueAsRawString()
+            assertTrue(pattern.matcher(value).find())
+        }
+    }
+
+    @Test
+    fun testJVMInlineCanDisableExternalFlag() {
+
+        val regex = "^(?-i:abc)$"
+        val withExternalCI = RegexHandler.createGeneForJVM(regex, RegexFlags.fromJavaFlags(Pattern.CASE_INSENSITIVE))
+        val rand = Randomness()
+
+        repeat(200) {
+            withExternalCI.randomize(rand, false)
+            val value = withExternalCI.getValueAsRawString()
+            assertEquals("abc", value)
+        }
     }
 }


### PR DESCRIPTION
Added support for external flag usage in Java regex. In Java the `Pattern.compile` method can take an integer representing the flag values, we can grab that value from the matcher in the Java client, pass it and use it to set the starting flag values for the visitor. This way we apply the external flags globally (unless overridden by flag embeddings).