### PR TITLE
Java regex quote (\Q...\E) bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
+# IntelliJ ANTLR plugin recognizer default locations:
+core/gen/
+core/src/main/antlr4/org/evomaster/core/parser/gen
+
 **/*.DS_Store
 /.idea/
 .idea/
@@ -33,8 +37,6 @@ client-java/instrumentation-shared/target/
 client-java/database-spy/target/
 client-java/ci-utils/target
 core/target/
-# IntelliJ ANTLR plugin recognizer default location:
-core/gen/
 /core-tests/e2e-tests/dropwizard-examples/target/
 /core-tests/e2e-tests/e2e-tests-utils/target/
 /core-tests/e2e-tests/spring/spring-rest-openapi-v2/target/

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ client-java/instrumentation-shared/target/
 client-java/database-spy/target/
 client-java/ci-utils/target
 core/target/
+# IntelliJ ANTLR plugin recognizer default location:
+core/gen/
 /core-tests/e2e-tests/dropwizard-examples/target/
 /core-tests/e2e-tests/e2e-tests-utils/target/
 /core-tests/e2e-tests/spring/spring-rest-openapi-v2/target/

--- a/core/src/main/antlr4/org/evomaster/core/parser/RegexJavaLexer.g4
+++ b/core/src/main/antlr4/org/evomaster/core/parser/RegexJavaLexer.g4
@@ -1,0 +1,136 @@
+/*
+    This is the lexer grammar for the RegexJava grammar, see RegexJavaParser.g4 (parser grammar) for more information.
+*/
+
+lexer grammar RegexJavaLexer;
+
+
+//------ LEXER ------------------------------
+// Lexer rules have first letter in upper-case
+
+NAMED_CAPTURE_GROUP_OPEN
+ : '(?<' [a-zA-Z] [a-zA-Z0-9]* '>'
+ ;
+
+FLAG_GROUP_OPEN
+ : PAREN_open QUESTION [idmsuxU]+ (MINUS [idmsuxU]+)? COLON
+ | PAREN_open QUESTION MINUS [idmsuxU]+ COLON
+ ;
+
+FLAG_SCOPE_OPEN
+ : PAREN_open QUESTION [idmsuxU]+ (MINUS [iumdsx]+)? PAREN_close
+ | PAREN_open QUESTION MINUS [idmsuxU]+ PAREN_close
+ ;
+
+CharacterEscape
+ : SLASH ControlEscape
+ | SLASH 'c' ControlLetter
+ | SLASH HexEscapeSequence
+ | SLASH UnicodeEscapeSequence
+ | SLASH OctalEscapeSequence
+ | SLASH ('p' | 'P') BRACE_open PCharacterClassEscapeLabel BRACE_close // this is only implemented in Java at the moment
+                                                        // as on JS this is allowed only while certain flags are enabled
+ | SLASH ~[a-zA-Z0-9] // identity escape
+ ;
+
+// Instead of listing all unicode scripts, blocks, etc. the parser allows anything
+// then we filter by checking if the label is valid when it is used.
+fragment PCharacterClassEscapeLabel
+ : [0-9a-zA-Z_=]+
+// posix character classes, java.lang.Character methods and Unicode scripts, blocks, categories and binary properties.
+// https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#:~:text=character%3A%20%5B%5E%5Cw%5D-,POSIX,-character%20classes%20(US
+// https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#jcc
+// https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#usc
+// https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#ubc
+// https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#ucc
+// https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#ubpc
+ ;
+
+fragment ControlEscape
+ //one of f n r t v
+ : [aefnrt]
+ ;
+
+fragment ControlLetter
+ : [?-_a-z]
+ ;
+
+//TODO
+//DecimalEscape
+// //[lookahead ∉ DecimalDigit]
+// : DecimalIntegerLiteral
+// ;
+
+DOUBLE_AMPERSAND
+ : '&&'
+ ;
+
+DecimalDigit
+ : [0-9]
+ ;
+
+CharacterClassEscape
+ //one of d D s S w W v V h H
+  // v, V, h and H are java8 exclusive, they represent vertical spaces and horizaontal spaces respectively
+  // see https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html for more information
+  : SLASH [dDsSwWvVhH]
+ ;
+
+CARET                      : '^';
+DOLLAR                     : '$';
+SLASH                      : '\\';
+DOT                        : '.';
+STAR                       : '*';
+PLUS                       : '+';
+QUESTION                   : '?';
+PAREN_open                 : '(';
+PAREN_close                : ')';
+BRACKET_open               : '[';
+BRACKET_close              : ']';
+BRACE_open                 : '{';
+BRACE_close                : '}';
+OR                         : '|';
+MINUS                      : '-';
+COMMA                      : ',';
+COLON                      : ':';
+
+Q: 'Q';
+E: 'E';
+
+BaseChar
+ // practically all chars but the ones used for control and digits
+ : ~[0-9:,^$\\.*+?()[\]{}|-]
+ ;
+
+fragment OctalEscapeSequence
+ : '0' OctalDigit
+ | '0' OctalDigit OctalDigit
+ | '0' [0-3] OctalDigit OctalDigit
+;
+
+fragment UnicodeEscapeSequence:
+ 'u' HexDigit HexDigit HexDigit HexDigit
+;
+
+fragment HexEscapeSequence
+ : 'x' HexDigit HexDigit
+ | 'x' BRACE_open HexDigit+ BRACE_close
+ ;
+
+fragment HexDigit:
+ [a-fA-F0-9]
+ ;
+
+fragment OctalDigit:
+ [0-7]
+ ;
+
+ // \1, \2, ... \99 etc, distinguished from \0XX octal which starts with 0
+ BackReference
+  : SLASH [1-9] DecimalDigit*
+  ;
+
+// \k<name>, first character must be letter, following characters may be letters or digits
+NamedBackReference
+ : SLASH 'k<' [a-zA-Z] [a-zA-Z0-9]* '>'
+ ;

--- a/core/src/main/antlr4/org/evomaster/core/parser/RegexJavaLexer.g4
+++ b/core/src/main/antlr4/org/evomaster/core/parser/RegexJavaLexer.g4
@@ -94,9 +94,6 @@ MINUS                      : '-';
 COMMA                      : ',';
 COLON                      : ':';
 
-Q: 'Q';
-E: 'E';
-
 BaseChar
  // practically all chars but the ones used for control and digits
  : ~[0-9:,^$\\.*+?()[\]{}|-]
@@ -133,4 +130,34 @@ fragment OctalDigit:
 // \k<name>, first character must be letter, following characters may be letters or digits
 NamedBackReference
  : SLASH 'k<' [a-zA-Z] [a-zA-Z0-9]* '>'
+ ;
+
+// Special for Java: \Q...\E literal quoting.
+// Matching '\Q' switches the lexer into QUOTE_MODE (see below).
+QUOTE_OPEN
+ : '\\' 'Q' -> pushMode(QUOTE_MODE)
+ ;
+
+
+
+// --------------------------------------------------------------------------------
+// QUOTE_MODE: everything after \Q and before an optional \E is literal text.
+// By using lexer modes we skip having to explicitly allow all lexer tokens to appear
+// within quotes. This works by having a different set of tokens available when inside
+// a quote block, the default mode and the QUOTE_MODE each keep their own set of tokens.
+// QUOTE_MODE only has the lexer tokens defined below.
+// --------------------------------------------------------------------------------
+mode QUOTE_MODE;
+
+// The only way out of a \Q...\E block. In Java the first literal "\E" sequence ends quoting.
+QUOTE_CLOSE
+ : '\\' 'E' -> popMode
+ ;
+
+// One or more characters that do not form a "\E" sequence, so either:
+// - a backslash immediately followed by something other than 'E',
+// - any single non-backslash character.
+// Note that this cannot consume the sequence QUOTE_CLOSE.
+QUOTE_CONTENT
+ : ( '\\' ~[E] | ~[\\] )+
  ;

--- a/core/src/main/antlr4/org/evomaster/core/parser/RegexJavaParser.g4
+++ b/core/src/main/antlr4/org/evomaster/core/parser/RegexJavaParser.g4
@@ -167,7 +167,7 @@ classAtomNoDash
  | BaseChar
  | DecimalDigit
  | COMMA | CARET | DOLLAR | DOT | STAR | PLUS | QUESTION
- | PAREN_open | PAREN_close | BRACKET_open | BRACE_open | BRACE_close | OR | E | Q
+ | PAREN_open | PAREN_close | BRACKET_open | BRACE_open | BRACE_close | OR
  | COLON
  // should be interpreted literally:
  // As they are lexer tokens, these character sequences are captured as such. In particular these require some extra

--- a/core/src/main/antlr4/org/evomaster/core/parser/RegexJavaParser.g4
+++ b/core/src/main/antlr4/org/evomaster/core/parser/RegexJavaParser.g4
@@ -16,9 +16,9 @@
     Their implementation could hence be wrong/inefficient
 */
 
-grammar RegexJava;
+parser grammar RegexJavaParser;
 
-
+options { tokenVocab = RegexJavaLexer; }
 
 //------ PARSER ------------------------------
 // Parser rules have first letter in lower-case
@@ -98,20 +98,6 @@ atom
  | NAMED_CAPTURE_GROUP_OPEN disjunction PAREN_close // named capturing
  ;
 
-NAMED_CAPTURE_GROUP_OPEN
- : '(?<' [a-zA-Z] [a-zA-Z0-9]* '>'
- ;
-
-FLAG_GROUP_OPEN
- : PAREN_open QUESTION [idmsuxU]+ (MINUS [idmsuxU]+)? COLON
- | PAREN_open QUESTION MINUS [idmsuxU]+ COLON
- ;
-
-FLAG_SCOPE_OPEN
- : PAREN_open QUESTION [idmsuxU]+ (MINUS [iumdsx]+)? PAREN_close
- | PAREN_open QUESTION MINUS [idmsuxU]+ PAREN_close
- ;
-
 // Special for Java
 quote
  : SLASH Q quoteBlock SLASH E
@@ -128,45 +114,6 @@ quoteChar
  | Q
  | E
 ;
-
-CharacterEscape
- : SLASH ControlEscape
- | SLASH 'c' ControlLetter
- | SLASH HexEscapeSequence
- | SLASH UnicodeEscapeSequence
- | SLASH OctalEscapeSequence
- | SLASH ('p' | 'P') BRACE_open PCharacterClassEscapeLabel BRACE_close // this is only implemented in Java at the moment
-                                                        // as on JS this is allowed only while certain flags are enabled
- | SLASH ~[a-zA-Z0-9] // identity escape
- ;
-
-// Instead of listing all unicode scripts, blocks, etc. the parser allows anything
-// then we filter by checking if the label is valid when it is used.
-fragment PCharacterClassEscapeLabel
- : [0-9a-zA-Z_=]+
-// posix character classes, java.lang.Character methods and Unicode scripts, blocks, categories and binary properties.
-// https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#:~:text=character%3A%20%5B%5E%5Cw%5D-,POSIX,-character%20classes%20(US
-// https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#jcc
-// https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#usc
-// https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#ubc
-// https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#ucc
-// https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#ubpc
- ;
-
-fragment ControlEscape
- //one of f n r t v
- : [aefnrt]
- ;
-
-fragment ControlLetter
- : [?-_a-z]
- ;
-
-//TODO
-//DecimalEscape
-// //[lookahead ∉ DecimalDigit]
-// : DecimalIntegerLiteral
-// ;
 
 patternCharacter
  // SourceCharacter but not one of ^ $ \ . * + ? ( ) [ ] { } |
@@ -255,87 +202,3 @@ atomEscape
  | BackReference
  | NamedBackReference
  ;
-
-//------ LEXER ------------------------------
-// Lexer rules have first letter in upper-case
-
-DOUBLE_AMPERSAND
- : '&&'
- ;
-
-DecimalDigit
- : [0-9]
- ;
-
-CharacterClassEscape
- //one of d D s S w W v V h H
-  // v, V, h and H are java8 exclusive, they represent vertical spaces and horizaontal spaces respectively
-  // see https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html for more information
-  : SLASH [dDsSwWvVhH]
- ;
-
-CARET                      : '^';
-DOLLAR                     : '$';
-SLASH                      : '\\';
-DOT                        : '.';
-STAR                       : '*';
-PLUS                       : '+';
-QUESTION                   : '?';
-PAREN_open                 : '(';
-PAREN_close                : ')';
-BRACKET_open               : '[';
-BRACKET_close              : ']';
-BRACE_open                 : '{';
-BRACE_close                : '}';
-OR                         : '|';
-MINUS                      : '-';
-COMMA                      : ',';
-COLON                      : ':';
-
-Q: 'Q';
-E: 'E';
-
-
-BaseChar
- // practically all chars but the ones used for control and digits
- : ~[0-9:,^$\\.*+?()[\]{}|-]
- ;
-
-fragment OctalEscapeSequence
- : '0' OctalDigit
- | '0' OctalDigit OctalDigit
- | '0' [0-3] OctalDigit OctalDigit
-;
-
-fragment UnicodeEscapeSequence:
- 'u' HexDigit HexDigit HexDigit HexDigit
-;
-
-fragment HexEscapeSequence
- : 'x' HexDigit HexDigit
- | 'x' BRACE_open HexDigit+ BRACE_close
- ;
-
-fragment HexDigit:
- [a-fA-F0-9]
- ;
-
-fragment OctalDigit:
- [0-7]
- ;
-
- // \1, \2, ... \99 etc, distinguished from \0XX octal which starts with 0
- BackReference
-  : SLASH [1-9] DecimalDigit*
-  ;
-
-// \k<name>, first character must be letter, following characters may be letters or digits
-NamedBackReference
- : SLASH 'k<' [a-zA-Z] [a-zA-Z0-9]* '>'
- ;
-
-
-
-
-
-

--- a/core/src/main/antlr4/org/evomaster/core/parser/RegexJavaParser.g4
+++ b/core/src/main/antlr4/org/evomaster/core/parser/RegexJavaParser.g4
@@ -103,19 +103,7 @@ atom
 
 // Special for Java
 quote
- : SLASH Q quoteBlock SLASH E
-;
-
-quoteBlock
-  : quoteChar*
-;
-
-quoteChar
- : classAtom
- | SLASH
- | BRACKET_close
- | Q
- | E
+ : QUOTE_OPEN QUOTE_CONTENT? QUOTE_CLOSE? // both the content and closing the quote is optional in java regex.
 ;
 
 patternCharacter
@@ -125,7 +113,6 @@ patternCharacter
  | COMMA
  | MINUS
  | DecimalDigit
- | E | Q
  // These are also allowed as literals when no matching pair exists
  | BRACE_close
  | BRACKET_close

--- a/core/src/main/antlr4/org/evomaster/core/parser/RegexJavaParser.g4
+++ b/core/src/main/antlr4/org/evomaster/core/parser/RegexJavaParser.g4
@@ -20,6 +20,9 @@ parser grammar RegexJavaParser;
 
 options { tokenVocab = RegexJavaLexer; }
 
+// NOTE: if IntelliJ shows errors in this file its because it does not have a recognizer for the lexer, to solve this:
+// Right click the lexer file and press "Generate ANTLR Recognizer", after a few seconds it should stop showing errors.
+
 //------ PARSER ------------------------------
 // Parser rules have first letter in lower-case
 

--- a/core/src/main/kotlin/org/evomaster/core/parser/GeneRegexJavaVisitor.kt
+++ b/core/src/main/kotlin/org/evomaster/core/parser/GeneRegexJavaVisitor.kt
@@ -11,7 +11,7 @@ private const val EOF_TOKEN = "<EOF>"
 /**
  * Created by arcuri82 on 11-Sep-19.
  */
-class GeneRegexJavaVisitor(externalRegexFlags: RegexFlags = RegexFlags()) : RegexJavaBaseVisitor<VisitResult>(){
+class GeneRegexJavaVisitor(externalRegexFlags: RegexFlags = RegexFlags()) : RegexJavaParserBaseVisitor<VisitResult>(){
 
     private val hexEscapePrefixes = setOf('x', 'u')
 

--- a/core/src/main/kotlin/org/evomaster/core/parser/GeneRegexJavaVisitor.kt
+++ b/core/src/main/kotlin/org/evomaster/core/parser/GeneRegexJavaVisitor.kt
@@ -366,8 +366,7 @@ class GeneRegexJavaVisitor(externalRegexFlags: RegexFlags = RegexFlags()) : Rege
 
         if(ctx.quote() != null){
 
-            val block = ctx.quote().quoteBlock().quoteChar().map { it.text }
-                    .joinToString("")
+            val block = ctx.quote().QUOTE_CONTENT()?.text ?: ""
 
             val name = if(block.isBlank()) "blankBlock" else block
 

--- a/core/src/test/kotlin/org/evomaster/core/parser/GeneRegexJavaVisitorTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/parser/GeneRegexJavaVisitorTest.kt
@@ -56,6 +56,7 @@ class GeneRegexJavaVisitorTest : GeneRegexEcma262VisitorTest() {
         checkSameAsJava("^(\\Q6\\E(n|N)(u|U)(a|A)(q|Q)(w|W)(b|B)\\Q51\\E(y|Y)(w|W)\\Q1\\E(e|E)(r|R)(n|N))$")
         checkSameAsJava("^((z|Z)(l|L)(q|Q)\\Q9\\E(r|R)(e|E)(k|K)(q|Q)(b|B)\\Q6\\E(e|E)(q|Q)(u|U))$")
         checkSameAsJava("^(\\Q81\\E(x|X)(a|A)\\Q3\\E(p|P)(x|X)(d|D))$")
+        checkSameAsJava("a{1}\\Qa{1}\\Qabcd")
     }
 
     @Test

--- a/core/src/test/kotlin/org/evomaster/core/parser/GeneRegexJavaVisitorTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/parser/GeneRegexJavaVisitorTest.kt
@@ -52,6 +52,13 @@ class GeneRegexJavaVisitorTest : GeneRegexEcma262VisitorTest() {
     }
 
     @Test
+    fun testMultipleQuotes(){
+        checkSameAsJava("^(\\Q6\\E(n|N)(u|U)(a|A)(q|Q)(w|W)(b|B)\\Q51\\E(y|Y)(w|W)\\Q1\\E(e|E)(r|R)(n|N))$")
+        checkSameAsJava("^((z|Z)(l|L)(q|Q)\\Q9\\E(r|R)(e|E)(k|K)(q|Q)(b|B)\\Q6\\E(e|E)(q|Q)(u|U))$")
+        checkSameAsJava("^(\\Q81\\E(x|X)(a|A)\\Q3\\E(p|P)(x|X)(d|D))$")
+    }
+
+    @Test
     fun testIssueWithControlCharactersInIgnoreCase(){
         val s = "a[](){}\\\"^$.b"
         checkCanSample(RegexUtils.ignoreCaseRegex(s), listOf(s.uppercase(), s.lowercase()), 200)


### PR DESCRIPTION
Fixed a bug with java regex quoting.

Currently, when multiple quotes appear in one regex we took the first `\Q` and matched it with the last `\E`, ignoring the rest, this results in regex like `^(\\Q81\\E(x|X)(a|A)\\Q3\\E(p|P)(x|X)(d|D))$` sampling things like `81\\Exa\\Q3\\Epxd` instead of `81xa3pxd`. We also needed to explicitly allow all lexer tokens on the `quoteChar` parser rule before.

This PR solves both, by splitting the `RegexJava.g4` combined grammar into `RegexJavaParser.g4` (parser grammar) and `RegexJavaLexer.g4` (lexer grammar) we can now use lexer modes to define separate set of lexer tokens depending on the context.  This lets us solve the two problems.

Note: the diff might look large as the combined file got deleted and two new files appeared but there where only some minor changes to the actual grammar regarding quoting.