### PR TITLE
Fix REST path encoding, Java Unicode escaping, and monitor initialization

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/output/MongoWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/MongoWriter.kt
@@ -58,8 +58,9 @@ object MongoWriter {
                         .forEach { g ->
                             when (g) {
                                 is ObjectGene -> {
-                                    val printableValue =
-                                        StringEscapeUtils.escapeJava(g.getValueAsPrintableString(mode = GeneUtils.EscapeMode.EJSON))
+                                    val ejson = g.getValueAsPrintableString(mode = GeneUtils.EscapeMode.EJSON)
+                                    val printableValue = if (format.isJava()) escapeEjsonForJavaLiteral(ejson)
+                                    else StringEscapeUtils.escapeJava(ejson)
                                     val adaptedPrintableValue = if (format.isKotlin())
                                         printableValue.replace(
                                             "$",
@@ -94,5 +95,23 @@ object MongoWriter {
         insertionVars.add(insertionVar to insertionVarResult)
 
     }
+
+    /**
+     * Escapes literal backslash-u sequences in EJSON for a Java string literal.
+     * Java translates eligible Unicode escapes before parsing string literals,
+     * so those sequences can make otherwise valid generated tests fail to compile.
+     * Octal escapes preserve the runtime backslashes without changing genuine
+     * Unicode escapes emitted by [StringEscapeUtils.escapeJava].
+     */
+    internal fun escapeEjsonForJavaLiteral(value: String): String {
+        return StringEscapeUtils.escapeJava(value).replace(ESCAPED_BACKSLASH_U) { match ->
+            val slashCount = match.value.length - 1
+            "\\134".repeat(slashCount / 2) + "u"
+        }
+    }
+
+    // Literal backslashes produce complete even-length runs before 'u'. A genuine
+    // Unicode escape, including one after literal backslashes, has an odd-length run.
+    private val ESCAPED_BACKSLASH_U = Regex("""(?<!\\)(\\\\)+u""")
 
 }

--- a/core/src/main/kotlin/org/evomaster/core/problem/rest/data/RestPath.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/rest/data/RestPath.kt
@@ -413,7 +413,9 @@ class RestPath(path: String) {
                             why not using URI also for Query part???
                             it seems unclear how to properly build it as a single string...
                          */
-                        val entry = URI(null, null, path.toString(), null, null).toASCIIString()
+                        val entry = encodeNonAsciiPathCharacters(
+                            URI(null, null, path.toString(), null, null).rawPath
+                        )
                         data.add(Pair(entry, false))
                         path.setLength(0) // clear it
                         data.add(Pair(variable, true))
@@ -446,7 +448,9 @@ class RestPath(path: String) {
         }
 
         if(path.isNotEmpty()){
-            val entry = URI(null, null, path.toString(), null, null).toASCIIString()
+            val entry = encodeNonAsciiPathCharacters(
+                URI(null, null, path.toString(), null, null).rawPath
+            )
             data.add(Pair(entry, false))
         }
 
@@ -469,6 +473,25 @@ class RestPath(path: String) {
      */
     private fun encode(s: String): String {
         return URLEncoder.encode(s, "UTF-8")
+    }
+
+    /**
+     * [URI.rawPath] leaves non-ASCII path characters unencoded. Process them
+     * by code point so valid surrogate pairs are kept together. An isolated
+     * surrogate is encoded by [URLEncoder] as `%3F` instead of failing.
+     */
+    private fun encodeNonAsciiPathCharacters(path: String): String {
+        val result = StringBuilder()
+        var index = 0
+
+        while (index < path.length) {
+            val codePoint = Character.codePointAt(path, index)
+            val value = String(Character.toChars(codePoint))
+            result.append(if (codePoint > 127) encode(value) else value)
+            index += Character.charCount(codePoint)
+        }
+
+        return result.toString()
     }
 
     fun copy(): RestPath {

--- a/core/src/main/kotlin/org/evomaster/core/search/gene/utils/GeneUtils.kt
+++ b/core/src/main/kotlin/org/evomaster/core/search/gene/utils/GeneUtils.kt
@@ -295,6 +295,12 @@ object GeneUtils {
                 .replace("\b", "\\b")
                 .replace("\t", "\\t")
 
+        if (format.isJava()) {
+            // Java translates eligible Unicode escapes before tokenizing string literals.
+            // Keep the even source-backslash count so a backslash-u sequence stays literal.
+            return ret
+        }
+
         if (format.isKotlin()) return ret.replace("\$", "\\\$")
                 .replace("\\\\u", "\\u")
         //.replace("\$", "\${\'\$\'}")

--- a/core/src/main/kotlin/org/evomaster/core/search/gene/utils/GeneUtils.kt
+++ b/core/src/main/kotlin/org/evomaster/core/search/gene/utils/GeneUtils.kt
@@ -295,27 +295,20 @@ object GeneUtils {
                 .replace("\b", "\\b")
                 .replace("\t", "\\t")
 
-        if (format.isJava()) {
-            // Java translates eligible Unicode escapes before tokenizing string literals.
-            // Keep the even source-backslash count so a backslash-u sequence stays literal.
-            return ret
+        return when {
+            format.isKotlin() -> {
+                // JVM source must retain the doubled backslash. For example, input \uquWOnj must
+                // be emitted as "\\uquWOnj": "\uquWOnj" is invalid, while a valid sequence
+                // such as "\u0041" would silently change the runtime value to "A".
+                ret.replace("\$", "\\\$")
+            }
+            format.isJava() -> {
+                // Java translates eligible Unicode escapes before tokenizing string literals, so
+                // retaining the doubled source backslash also keeps the runtime sequence literal.
+                ret
+            }
+            else -> ret.replace("\\\\u", "\\u")
         }
-
-        if (format.isKotlin()) return ret.replace("\$", "\\\$")
-                .replace("\\\\u", "\\u")
-        //.replace("\$", "\${\'\$\'}")
-        //ret.replace("\$", "\\\$")
-        else return ret.replace("\\\\u", "\\u")
-
-        /*
-                   The \u denote unicode characters. For some reason, escaping the \\ leads to these being invalid.
-                     Since they are valid in the back end (and they should, arguably, be possible), this leads to inconsistent behaviour.
-                     This fix is a hack. It may be that some \u chars are not valid. E.g. \uAndSomeRubbish.
-
-                     As far as I understand, the addition of an \ in the \unicode should not really happen.
-                     They should be their own chars, and the .replace("\\", """\\""" should be fine, but for some reason
-                     they are not.
-                     */
     }
 
     private fun applySqlEscapes(string: String, format: OutputFormat): String {

--- a/core/src/main/kotlin/org/evomaster/core/search/service/monitor/SearchProcessMonitor.kt
+++ b/core/src/main/kotlin/org/evomaster/core/search/service/monitor/SearchProcessMonitor.kt
@@ -109,8 +109,8 @@ class SearchProcessMonitor: SearchListener {
 
     @PostConstruct
     fun postConstruct(){
-        initMonitorProcessOutputs()
         if(config.enableProcessMonitor){
+            initMonitorProcessOutputs()
             time.addListener(this)
             if (config.processFormat == EMConfig.ProcessDataFormat.TEST_IND || config.processFormat == EMConfig.ProcessDataFormat.TARGET_TEST_IND){
                 val dto = try {

--- a/core/src/test/kotlin/org/evomaster/core/output/MongoWriterTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/output/MongoWriterTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("DEPRECATION")
-
 package org.evomaster.core.output
 
 import org.apache.commons.lang3.StringEscapeUtils

--- a/core/src/test/kotlin/org/evomaster/core/output/MongoWriterTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/output/MongoWriterTest.kt
@@ -1,0 +1,36 @@
+@file:Suppress("DEPRECATION")
+
+package org.evomaster.core.output
+
+import org.apache.commons.lang3.StringEscapeUtils
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class MongoWriterTest {
+
+    @Test
+    fun `should escape literal backslash u without changing its runtime value`() {
+        val cases = mapOf(
+            """{"field":"El24e\uJTQGh"}""" to """{\"field\":\"El24e\134uJTQGh\"}""",
+            """{"field":"El24e\\uJTQGh"}""" to """{\"field\":\"El24e\134\134uJTQGh\"}""",
+            """{"field":"\u0041"}""" to """{\"field\":\"\134u0041\"}"""
+        )
+
+        cases.forEach { (ejson, expected) ->
+            val escaped = MongoWriter.escapeEjsonForJavaLiteral(ejson)
+
+            assertEquals(expected, escaped)
+            assertEquals(ejson, StringEscapeUtils.unescapeJava(escaped))
+        }
+    }
+
+    @Test
+    fun `should not rewrite unicode escapes created by escapeJava`() {
+        listOf("\\é", "\\😀", "é", "😀").forEach { ejson ->
+            val escaped = MongoWriter.escapeEjsonForJavaLiteral(ejson)
+
+            assertEquals(StringEscapeUtils.escapeJava(ejson), escaped)
+            assertEquals(ejson, StringEscapeUtils.unescapeJava(escaped))
+        }
+    }
+}

--- a/core/src/test/kotlin/org/evomaster/core/problem/rest/RestPathTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/problem/rest/RestPathTest.kt
@@ -5,6 +5,7 @@ import org.evomaster.core.output.OutputFormat
 import org.evomaster.core.problem.rest.builder.RestActionBuilderV3
 import org.evomaster.core.problem.rest.data.HttpVerb
 import org.evomaster.core.problem.rest.data.RestPath
+import org.evomaster.core.problem.rest.link.RestLinkParameter
 import org.evomaster.core.problem.rest.param.PathParam
 import org.evomaster.core.problem.rest.param.QueryParam
 import org.evomaster.core.search.gene.collection.ArrayGene
@@ -619,5 +620,45 @@ internal class RestPathTest{
             "Resolved path must not contain a raw non-ASCII character, got: $resolved")
         assertTrue(resolved.contains("%E8%81%9A"),
             "Resolved path must percent-encode non-ASCII characters, got: $resolved")
+    }
+
+    @Test
+    fun testPathParamWithSupplementaryUnicodeCharacter() {
+        val resolved = resolvePathParam("key-\uD83D\uDE00")
+
+        assertEquals("/api/key-%F0%9F%98%80", resolved)
+    }
+
+    @Test
+    fun testPathParamWithIsolatedSurrogates() {
+        listOf(0xD800, 0xDC00).forEach { surrogate ->
+            val resolved = resolvePathParam("key-${surrogate.toChar()}")
+
+            assertEquals("/api/key-%3F", resolved)
+        }
+    }
+
+    @Test
+    fun testDynamicPathDataEncodesUnicodeInEveryStaticSegment() {
+        val replacement = RestLinkParameter("path.key", "\$response.body#/id")
+
+        val tokens = RestPath("/api/\uD83D\uDE00/{key}/é").dynamicResolutionOnlyPathData(
+            listOf(),
+            mapOf("resolvedId" to replacement)
+        )
+
+        assertEquals(
+            listOf(
+                "/api/%F0%9F%98%80/" to false,
+                "resolvedId" to true,
+                "/%C3%A9" to false
+            ),
+            tokens
+        )
+    }
+
+    private fun resolvePathParam(value: String): String {
+        val key = PathParam("key", CustomMutationRateGene("d_", StringGene("key", value), 1.0))
+        return RestPath("/api/{key}").resolve(listOf(key))
     }
 }

--- a/core/src/test/kotlin/org/evomaster/core/search/gene/GeneUtilsEscapeTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/search/gene/GeneUtilsEscapeTest.kt
@@ -2,6 +2,7 @@ package org.evomaster.core.search.gene
 
 import org.evomaster.core.output.OutputFormat
 import org.evomaster.core.output.TestWriterUtils
+import org.evomaster.core.output.compiler.CompilerForTestGenerated
 import org.evomaster.core.output.formatter.OutputFormatter
 import org.evomaster.core.search.gene.string.StringGene
 import org.evomaster.core.search.gene.utils.GeneUtils
@@ -48,13 +49,19 @@ internal class GeneUtilsEscapeTest {
     }
 
     @Test
-    fun bodyEscapesKeepLiteralBackslashUForJava() {
+    fun bodyEscapesKeepLiteralBackslashUForJvmFormats() {
         val cases = mapOf(
             "\\uquWOnj" to "\\\\uquWOnj",
             "\\\\uquWOnj" to "\\\\\\\\uquWOnj"
         )
 
-        listOf(OutputFormat.JAVA_JUNIT_4, OutputFormat.JAVA_JUNIT_5).forEach { format ->
+        val formats = listOf(
+            OutputFormat.JAVA_JUNIT_4,
+            OutputFormat.JAVA_JUNIT_5,
+            OutputFormat.KOTLIN_JUNIT_4,
+            OutputFormat.KOTLIN_JUNIT_5
+        )
+        formats.forEach { format ->
             cases.forEach { (body, expected) ->
                 assertEquals(
                     expected,
@@ -65,10 +72,8 @@ internal class GeneUtilsEscapeTest {
     }
 
     @Test
-    fun bodyEscapesKeepExistingUnicodeHandlingForNonJavaFormats() {
+    fun bodyEscapesKeepExistingUnicodeHandlingForNonJvmFormats() {
         val formats = listOf(
-            OutputFormat.KOTLIN_JUNIT_4,
-            OutputFormat.KOTLIN_JUNIT_5,
             OutputFormat.JS_JEST,
             OutputFormat.PYTHON_UNITTEST
         )
@@ -92,6 +97,46 @@ internal class GeneUtilsEscapeTest {
             val slashCount = titleLine.substring(0, uIndex).takeLastWhile { it == '\\' }.length
 
             assertEquals(4, slashCount)
+        }
+    }
+
+    @Test
+    fun kotlinBodyWriterPreservesLiteralBackslashUAtRuntime() {
+        val cases = listOf(
+            "\\uquWOnj",
+            "\\u0041",
+            "\\\\uquWOnj",
+            "price-\$value"
+        )
+        val className = "KotlinBodyEscapeProbe"
+        val methods = cases.mapIndexed { index, body ->
+            val literal = TestWriterUtils.formatJsonWithEscapes(
+                body,
+                OutputFormat.KOTLIN_JUNIT_5,
+                extraSpace = ""
+            ).single()
+            "fun value$index(): String = $literal"
+        }
+        val code = buildString {
+            appendLine("class $className {")
+            methods.forEach { appendLine("    $it") }
+            appendLine("}")
+        }
+
+        CompilerForTestGenerated.compile(
+            OutputFormat.KOTLIN_JUNIT_5,
+            code,
+            className
+        )
+
+        val instance = this.javaClass.classLoader.loadClass(className)
+            .getDeclaredConstructor()
+            .newInstance()
+        cases.forEachIndexed { index, expected ->
+            assertEquals(
+                expected,
+                instance.javaClass.getDeclaredMethod("value$index").invoke(instance)
+            )
         }
     }
 }

--- a/core/src/test/kotlin/org/evomaster/core/search/gene/GeneUtilsEscapeTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/search/gene/GeneUtilsEscapeTest.kt
@@ -1,9 +1,11 @@
 package org.evomaster.core.search.gene
 
 import org.evomaster.core.output.OutputFormat
+import org.evomaster.core.output.TestWriterUtils
 import org.evomaster.core.output.formatter.OutputFormatter
 import org.evomaster.core.search.gene.string.StringGene
 import org.evomaster.core.search.gene.utils.GeneUtils
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -43,5 +45,53 @@ internal class GeneUtilsEscapeTest {
         OutputFormatter.JSON_FORMATTER.getFormatted(testJson.getValueAsPrintableString(mode = GeneUtils.EscapeMode.JSON, targetFormat = formatKotlin))
         OutputFormatter.JSON_FORMATTER.getFormatted(testJson.getValueAsPrintableString(mode = GeneUtils.EscapeMode.JSON, targetFormat = formatJava5))
 
+    }
+
+    @Test
+    fun bodyEscapesKeepLiteralBackslashUForJava() {
+        val cases = mapOf(
+            "\\uquWOnj" to "\\\\uquWOnj",
+            "\\\\uquWOnj" to "\\\\\\\\uquWOnj"
+        )
+
+        listOf(OutputFormat.JAVA_JUNIT_4, OutputFormat.JAVA_JUNIT_5).forEach { format ->
+            cases.forEach { (body, expected) ->
+                assertEquals(
+                    expected,
+                    GeneUtils.applyEscapes(body, GeneUtils.EscapeMode.BODY, format)
+                )
+            }
+        }
+    }
+
+    @Test
+    fun bodyEscapesKeepExistingUnicodeHandlingForNonJavaFormats() {
+        val formats = listOf(
+            OutputFormat.KOTLIN_JUNIT_4,
+            OutputFormat.KOTLIN_JUNIT_5,
+            OutputFormat.JS_JEST,
+            OutputFormat.PYTHON_UNITTEST
+        )
+
+        formats.forEach { format ->
+            assertEquals(
+                "\\uquWOnj",
+                GeneUtils.applyEscapes("\\uquWOnj", GeneUtils.EscapeMode.BODY, format)
+            )
+        }
+    }
+
+    @Test
+    fun jsonBodyWriterKeepsTheOriginalFailureSequenceJavaSafe() {
+        listOf(OutputFormat.JAVA_JUNIT_4, OutputFormat.JAVA_JUNIT_5).forEach { format ->
+            val titleLine = TestWriterUtils.formatJsonWithEscapes(
+                """{"title":"EWE\\uquWOnj"}""",
+                format
+            ).single { it.contains("uquWOnj") }
+            val uIndex = titleLine.indexOf("uquWOnj")
+            val slashCount = titleLine.substring(0, uIndex).takeLastWhile { it == '\\' }.length
+
+            assertEquals(4, slashCount)
+        }
     }
 }

--- a/core/src/test/kotlin/org/evomaster/core/search/service/ProcessMonitorTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/search/service/ProcessMonitorTest.kt
@@ -72,25 +72,34 @@ class ProcessMonitorTest{
 
     @Test
     fun testDisableProcessMonitor(){
+        val output = Files.createTempDirectory("process-monitor-disabled-")
+        val marker = output.resolve("marker")
+        Files.createFile(marker)
 
-        config.enableProcessMonitor = false
-        config.showProgress = true
+        try {
+            config.processFiles = output.toString()
+            config.enableProcessMonitor = false
+            config.showProgress = true
 
-        processMonitor.postConstruct()
-        assertFalse(Files.exists(Paths.get(config.processFiles)))
+            processMonitor.postConstruct()
+            assertTrue(Files.exists(marker))
 
-        val a = OneMaxIndividual(2)
-        TestUtils.doInitializeIndividualForTesting(a,randomness)
-        a.setValue(0, 1.0)
+            val a = OneMaxIndividual(2)
+            TestUtils.doInitializeIndividualForTesting(a,randomness)
+            a.setValue(0, 1.0)
 
-        val eval = ff.calculateCoverage(a, modifiedSpec = null)!!
-        processMonitor.eval = eval
-        processMonitor.newActionsEvaluated(1)
+            val eval = ff.calculateCoverage(a, modifiedSpec = null)!!
+            processMonitor.eval = eval
+            processMonitor.newActionsEvaluated(1)
 
-        val added = archive.addIfNeeded(eval)
-        processMonitor.record(added, true, eval)
+            val added = archive.addIfNeeded(eval)
+            processMonitor.record(added, true, eval)
 
-        assertFalse(Files.exists(Paths.get(config.processFiles)))
+            assertTrue(Files.exists(marker))
+        } finally {
+            Files.deleteIfExists(marker)
+            Files.deleteIfExists(output)
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

This PR fixes four independent failures observed while generating and running EvoMaster tests across the WebFuzzing SUT suite:

- Resolved REST path fragments can fail or be corrupted for lone surrogates, supplementary Unicode characters, and non-ASCII characters.
- Java Mongo initialization source can contain literal backslash-u sequences that interact with Java Unicode preprocessing.
- Java request-body source can collapse literal backslash-u sequences into invalid or value-changing Unicode escapes.
- Disabled process monitoring still initializes and deletes shared monitor output state, creating a concurrent filesystem race.

## Changes

- Encode non-ASCII resolved REST path fragments by Unicode code point and use URI raw paths, preserving valid surrogate pairs and handling isolated surrogates safely.
- Escape Java-only Mongo EJSON literal backslash-u runs with octal backslash escapes while preserving genuine Unicode escapes and runtime values.
- Preserve doubled source backslashes for Java BODY output so literal backslash-u values survive Java Unicode preprocessing.
- Initialize process-monitor output only when process monitoring is enabled.

## Scope

- REST encoding applies to resolved/static path fragments, including fragments around OpenAPI link variables. Runtime link-variable values remain outside this change.
- Mongo octal escaping applies only to Java output. Kotlin keeps its existing escaping behavior.
- BODY escaping changes only Java JUnit 4/5 output. Kotlin, JavaScript, and Python behavior is unchanged.
- Process-monitor behavior changes only when the monitor is disabled.

## Tests

- Added and extended regression coverage for BMP, supplementary, and isolated-surrogate REST path values; static fragments around runtime REST link variables; literal and genuine Unicode sequences in Java Mongo EJSON; Java BODY escaping through the JSON writer; and disabled process-monitor output isolation.
- Local targeted suite: 64 tests passed with no failures, errors, or skips.
- Additional local core coverage passed for all modified areas. Cases requiring unavailable external LLM/HTTP services or uncached Docker images are left to the fork CI environment.
- Experimental validation confirmed the affected SUT generation and execution paths.